### PR TITLE
Do some cleanup found by static analysis

### DIFF
--- a/src/main/java/org/cyclops/integratedtunnels/capability/network/FluidNetworkConfig.java
+++ b/src/main/java/org/cyclops/integratedtunnels/capability/network/FluidNetworkConfig.java
@@ -13,7 +13,7 @@ import org.cyclops.integratedtunnels.core.network.FluidNetwork;
  * @author rubensworks
  *
  */
-public class FluidNetworkConfig extends CapabilityConfig {
+public class FluidNetworkConfig extends CapabilityConfig<IFluidNetwork> {
 
     /**
      * The unique instance.

--- a/src/main/java/org/cyclops/integratedtunnels/capability/network/FluidNetworkConfig.java
+++ b/src/main/java/org/cyclops/integratedtunnels/capability/network/FluidNetworkConfig.java
@@ -6,9 +6,7 @@ import org.cyclops.commoncapabilities.CommonCapabilities;
 import org.cyclops.cyclopscore.config.extendedconfig.CapabilityConfig;
 import org.cyclops.cyclopscore.modcompat.capabilities.DefaultCapabilityStorage;
 import org.cyclops.integratedtunnels.api.network.IFluidNetwork;
-import org.cyclops.integratedtunnels.api.network.IItemNetwork;
 import org.cyclops.integratedtunnels.core.network.FluidNetwork;
-import org.cyclops.integratedtunnels.core.network.ItemNetwork;
 
 /**
  * Config for the item network capability.

--- a/src/main/java/org/cyclops/integratedtunnels/capability/network/ItemNetworkConfig.java
+++ b/src/main/java/org/cyclops/integratedtunnels/capability/network/ItemNetworkConfig.java
@@ -13,7 +13,7 @@ import org.cyclops.integratedtunnels.core.network.ItemNetwork;
  * @author rubensworks
  *
  */
-public class ItemNetworkConfig extends CapabilityConfig {
+public class ItemNetworkConfig extends CapabilityConfig<IItemNetwork> {
 
     /**
      * The unique instance.

--- a/src/main/java/org/cyclops/integratedtunnels/core/network/ItemNetwork.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/network/ItemNetwork.java
@@ -5,7 +5,6 @@ import com.google.common.cache.CacheBuilder;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.Triple;
 import org.cyclops.commoncapabilities.api.capability.inventorystate.IInventoryState;
 import org.cyclops.commoncapabilities.api.capability.itemhandler.DefaultSlotlessItemHandlerWrapper;

--- a/src/main/java/org/cyclops/integratedtunnels/core/part/PartTypeInterfacePositionedAddon.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/part/PartTypeInterfacePositionedAddon.java
@@ -136,9 +136,9 @@ public abstract class PartTypeInterfacePositionedAddon<N extends IPositionedAddo
         }
 
         @Override
-        public <T> T getCapability(Capability<T> capability) {
+        public <T2> T2 getCapability(Capability<T2> capability) {
             if (getPositionedAddonsNetwork() != null && capability == getTargetCapability()) {
-                return (T) this;
+                return (T2) this;
             }
             return super.getCapability(capability);
         }

--- a/src/main/java/org/cyclops/integratedtunnels/core/part/PartTypeTunnel.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/part/PartTypeTunnel.java
@@ -2,8 +2,6 @@ package org.cyclops.integratedtunnels.core.part;
 
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.inventory.Container;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
 import org.cyclops.cyclopscore.init.ModBase;
 import org.cyclops.integrateddynamics.IntegratedDynamics;
 import org.cyclops.integrateddynamics.api.part.IPartState;

--- a/src/main/java/org/cyclops/integratedtunnels/part/PartStateItem.java
+++ b/src/main/java/org/cyclops/integratedtunnels/part/PartStateItem.java
@@ -39,6 +39,6 @@ public class PartStateItem<P extends IPartTypeWriter> extends PartStatePositione
 
     @Override
     public int getSlotLimit(int slot) {
-        return getPositionedAddonsNetwork().getSlotLimit(slot);
+        return getPositionedAddonsNetwork() != null ? getPositionedAddonsNetwork().getSlotLimit(slot) : 0;
     }
 }

--- a/src/main/java/org/cyclops/integratedtunnels/part/PartStateItem.java
+++ b/src/main/java/org/cyclops/integratedtunnels/part/PartStateItem.java
@@ -39,6 +39,6 @@ public class PartStateItem<P extends IPartTypeWriter> extends PartStatePositione
 
     @Override
     public int getSlotLimit(int slot) {
-        return getPositionedAddonsNetwork() != null ? getPositionedAddonsNetwork().getSlotLimit(slot) : null;
+        return getPositionedAddonsNetwork().getSlotLimit(slot);
     }
 }


### PR DESCRIPTION
Remove useless null check
Trying to return null from a method that's supposed to return an int will
itself cause an exception, so this check isn't actually preventing any
exception.


Rename template parameter to avoid hiding the one from the class

Remove unnecessary imports

Specify type parameter of superclasses