### PR TITLE
Potentially naive but operational solution to matchStack collision issue

### DIFF
--- a/src/main/java/org/cyclops/integratedtunnels/core/network/ItemNetwork.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/network/ItemNetwork.java
@@ -202,6 +202,9 @@ public class ItemNetwork extends PositionedAddonsNetwork implements IItemNetwork
             ISlotlessItemHandler itemHandler = getSlotlessItemHandler(partPos);
             if (itemHandler != null) {
                 disablePosition(partPos.getPartPos());
+                if (!simulate) {
+                    matchStack = matchStack.copy();
+                }
                 ItemStack extracted = itemHandler.extractItem(matchStack, matchFlags, simulate);
                 enablePosition(partPos.getPartPos());
                 if (!extracted.isEmpty()) {


### PR DESCRIPTION
This simply copies the matchstack at the point of extraction for comparison purposes down the road, circumventing the problem of the `matchStack` var actually referencing the physical stack in the inventory itself, and thus being changed when the item is extracted from the source and failing any subsequent match tests. Not sure if this is actually the correct solution not knowing whether this has repercussions elsewhere, but it does appear to solve issue #68.