### PR TITLE
Add config options for power consumption of individual network components

### DIFF
--- a/src/main/java/org/cyclops/integratedtunnels/GeneralConfig.java
+++ b/src/main/java/org/cyclops/integratedtunnels/GeneralConfig.java
@@ -75,6 +75,170 @@ public class GeneralConfig extends DummyConfig {
      */
     @ConfigurableProperty(category = ConfigurableTypeCategory.CORE, comment = "If items should be ejected into the world when item movement failed due to item handlers declaring inconsistent movement in simulation mode. If disabled, items can be voided.", isCommandable = true)
     public static boolean ejectItemsOnInconsistentSimulationMovement = true;
+    
+    /**
+     * The base energy usage for the energy exporter.
+     */
+    @ConfigurableProperty(category = ConfigurableTypeCategory.GENERAL, comment = "The base energy usage for the energy exporter.", minimalValue = 0)
+    public static int exporterEnergyBaseConsumption = 1;
+    
+    /**
+     * The base energy usage for the fluid exporter.
+     */
+    @ConfigurableProperty(category = ConfigurableTypeCategory.GENERAL, comment = "The base energy usage for the fluid exporter.", minimalValue = 0)
+    public static int exporterFluidBaseConsumption = 1;
+    
+    /**
+     * The base energy usage for the item exporter.
+     */
+    @ConfigurableProperty(category = ConfigurableTypeCategory.GENERAL, comment = "The base energy usage for the item exporter.", minimalValue = 0)
+    public static int exporterItemBaseConsumption = 1;
+    
+    /**
+     * The base energy usage for the world block exporter when it has a variable.
+     */
+    @ConfigurableProperty(category = ConfigurableTypeCategory.GENERAL, comment = "The base energy usage for the world block exporter when it has a variable.", minimalValue = 0)
+    public static int exporterWorldBlockBaseConsumptionEnabled = 32;
+    
+    /**
+     * The base energy usage for the world block exporter when it does not have a variable.
+     */
+    @ConfigurableProperty(category = ConfigurableTypeCategory.GENERAL, comment = "The base energy usage for the world block exporter when it does not have a variable.", minimalValue = 0)
+    public static int exporterWorldBlockBaseConsumptionDisabled = 1;
+    
+    /**
+     * The base energy usage for the world energy exporter when it has a variable.
+     */
+    @ConfigurableProperty(category = ConfigurableTypeCategory.GENERAL, comment = "The base energy usage for the world energy exporter when it has a variable.", minimalValue = 0)
+    public static int exporterWorldEnergyBaseConsumptionEnabled = 32;
+    
+    /**
+     * The base energy usage for the world energy exporter when it does not have a variable.
+     */
+    @ConfigurableProperty(category = ConfigurableTypeCategory.GENERAL, comment = "The base energy usage for the world energy exporter when it does not have a variable.", minimalValue = 0)
+    public static int exporterWorldEnergyBaseConsumptionDisabled = 1;
+    
+    /**
+     * The base energy usage for the world fluid exporter when it has a variable.
+     */
+    @ConfigurableProperty(category = ConfigurableTypeCategory.GENERAL, comment = "The base energy usage for the world fluid exporter when it has a variable.", minimalValue = 0)
+    public static int exporterWorldFluidBaseConsumptionEnabled = 32;
+    
+    /**
+     * The base energy usage for the world fluid exporter when it does not have a variable.
+     */
+    @ConfigurableProperty(category = ConfigurableTypeCategory.GENERAL, comment = "The base energy usage for the world fluid exporter when it does not have a variable.", minimalValue = 0)
+    public static int exporterWorldFluidBaseConsumptionDisabled = 1;
+    
+    /**
+     * The base energy usage for the world item exporter when it has a variable.
+     */
+    @ConfigurableProperty(category = ConfigurableTypeCategory.GENERAL, comment = "The base energy usage for the world item exporter when it has a variable.", minimalValue = 0)
+    public static int exporterWorldItemBaseConsumptionEnabled = 32;
+    
+    /**
+     * The base energy usage for the world item exporter when it does not have a variable.
+     */
+    @ConfigurableProperty(category = ConfigurableTypeCategory.GENERAL, comment = "The base energy usage for the world item exporter when it does not have a variable.", minimalValue = 0)
+    public static int exporterWorldItemBaseConsumptionDisabled = 1;
+    
+    /**
+     * The base energy usage for the energy importer.
+     */
+    @ConfigurableProperty(category = ConfigurableTypeCategory.GENERAL, comment = "The base energy usage for the energy importer.", minimalValue = 0)
+    public static int importerEnergyBaseConsumption = 1;
+    
+    /**
+     * The base energy usage for the fluid importer.
+     */
+    @ConfigurableProperty(category = ConfigurableTypeCategory.GENERAL, comment = "The base energy usage for the fluid importer.", minimalValue = 0)
+    public static int importerFluidBaseConsumption = 1;
+    
+    /**
+     * The base energy usage for the item importer.
+     */
+    @ConfigurableProperty(category = ConfigurableTypeCategory.GENERAL, comment = "The base energy usage for the item importer.", minimalValue = 0)
+    public static int importerItemBaseConsumption = 1;
+    
+    /**
+     * The base energy usage for the world block importer when it has a variable.
+     */
+    @ConfigurableProperty(category = ConfigurableTypeCategory.GENERAL, comment = "The base energy usage for the world block importer when it has a variable.", minimalValue = 0)
+    public static int importerWorldBlockBaseConsumptionEnabled = 32;
+    
+    /**
+     * The base energy usage for the world block importer when it does not have a variable.
+     */
+    @ConfigurableProperty(category = ConfigurableTypeCategory.GENERAL, comment = "The base energy usage for the world block importer when it does not have a variable.", minimalValue = 0)
+    public static int importerWorldBlockBaseConsumptionDisabled = 1;
+    
+    /**
+     * The base energy usage for the world energy importer when it has a variable.
+     */
+    @ConfigurableProperty(category = ConfigurableTypeCategory.GENERAL, comment = "The base energy usage for the world energy importer when it has a variable.", minimalValue = 0)
+    public static int importerWorldEnergyBaseConsumptionEnabled = 32;
+    
+    /**
+     * The base energy usage for the world energy importer when it does not have a variable.
+     */
+    @ConfigurableProperty(category = ConfigurableTypeCategory.GENERAL, comment = "The base energy usage for the world energy importer when it does not have a variable.", minimalValue = 0)
+    public static int importerWorldEnergyBaseConsumptionDisabled = 1;
+    
+    /**
+     * The base energy usage for the world fluid importer when it has a variable.
+     */
+    @ConfigurableProperty(category = ConfigurableTypeCategory.GENERAL, comment = "The base energy usage for the world fluid importer when it has a variable.", minimalValue = 0)
+    public static int importerWorldFluidBaseConsumptionEnabled = 32;
+    
+    /**
+     * The base energy usage for the world fluid importer when it does not have a variable.
+     */
+    @ConfigurableProperty(category = ConfigurableTypeCategory.GENERAL, comment = "The base energy usage for the world fluid importer when it does not have a variable.", minimalValue = 0)
+    public static int importerWorldFluidBaseConsumptionDisabled = 1;
+    
+    /**
+     * The base energy usage for the world item importer when it has a variable.
+     */
+    @ConfigurableProperty(category = ConfigurableTypeCategory.GENERAL, comment = "The base energy usage for the world item importer when it has a variable.", minimalValue = 0)
+    public static int importerWorldItemBaseConsumptionEnabled = 32;
+    
+    /**
+     * The base energy usage for the world item importer when it does not have a variable.
+     */
+    @ConfigurableProperty(category = ConfigurableTypeCategory.GENERAL, comment = "The base energy usage for the world item importer when it does not have a variable.", minimalValue = 0)
+    public static int importerWorldItemBaseConsumptionDisabled = 1;
+    
+    /**
+     * The base energy usage for the energy interface.
+     */
+    @ConfigurableProperty(category = ConfigurableTypeCategory.GENERAL, comment = "The base energy usage for the energy interface.", minimalValue = 0)
+    public static int interfaceEnergyBaseConsumption = 0;
+    
+    /**
+     * The base energy usage for the fluid interface.
+     */
+    @ConfigurableProperty(category = ConfigurableTypeCategory.GENERAL, comment = "The base energy usage for the fluid interface.", minimalValue = 0)
+    public static int interfaceFluidBaseConsumption = 0;
+    
+    /**
+     * The base energy usage for the item interface.
+     */
+    @ConfigurableProperty(category = ConfigurableTypeCategory.GENERAL, comment = "The base energy usage for the item interface.", minimalValue = 0)
+    public static int interfaceItemBaseConsumption = 0;
+    
+    /**
+     * The base energy usage for the player simulator when it has a variable.
+     */
+    @ConfigurableProperty(category = ConfigurableTypeCategory.GENERAL, comment = "The base energy usage for the player simulator when it has a variable.", minimalValue = 0)
+    public static int playerSimulatorBaseConsumptionEnabled = 64;
+    
+    /**
+     * The base energy usage for the player simulator when it does not have a variable.
+     */
+    @ConfigurableProperty(category = ConfigurableTypeCategory.GENERAL, comment = "The base energy usage for the player simulator when it does not have a variable.", minimalValue = 0)
+    public static int playerSimulatorBaseConsumptionDisabled = 1;
+    
+    
 
     /**
      * The type of this config.

--- a/src/main/java/org/cyclops/integratedtunnels/part/PartTypeExporterEnergy.java
+++ b/src/main/java/org/cyclops/integratedtunnels/part/PartTypeExporterEnergy.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import org.cyclops.integrateddynamics.api.part.aspect.IAspect;
 import org.cyclops.integrateddynamics.core.part.aspect.AspectRegistry;
 import org.cyclops.integrateddynamics.part.aspect.Aspects;
+import org.cyclops.integratedtunnels.GeneralConfig;
 import org.cyclops.integratedtunnels.core.part.PartTypeTunnelAspects;
 import org.cyclops.integratedtunnels.part.aspect.TunnelAspects;
 
@@ -23,5 +24,10 @@ public class PartTypeExporterEnergy extends PartTypeTunnelAspects<PartTypeExport
     @Override
     protected PartStateEnergy<PartTypeExporterEnergy> constructDefaultState() {
         return new PartStateEnergy<PartTypeExporterEnergy>(Aspects.REGISTRY.getWriteAspects(this).size(), false, true);
+    }
+    
+    @Override
+    public int getConsumptionRate(PartStateEnergy<PartTypeExporterEnergy> state) {
+        return GeneralConfig.exporterEnergyBaseConsumption;
     }
 }

--- a/src/main/java/org/cyclops/integratedtunnels/part/PartTypeExporterFluid.java
+++ b/src/main/java/org/cyclops/integratedtunnels/part/PartTypeExporterFluid.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import org.cyclops.integrateddynamics.api.part.aspect.IAspect;
 import org.cyclops.integrateddynamics.core.part.aspect.AspectRegistry;
 import org.cyclops.integrateddynamics.part.aspect.Aspects;
+import org.cyclops.integratedtunnels.GeneralConfig;
 import org.cyclops.integratedtunnels.core.part.PartTypeTunnelAspects;
 import org.cyclops.integratedtunnels.part.aspect.TunnelAspects;
 
@@ -27,5 +28,10 @@ public class PartTypeExporterFluid extends PartTypeTunnelAspects<PartTypeExporte
     @Override
     protected PartStateFluid<PartTypeExporterFluid> constructDefaultState() {
         return new PartStateFluid<PartTypeExporterFluid>(Aspects.REGISTRY.getWriteAspects(this).size(), false, true);
+    }
+    
+    @Override
+    public int getConsumptionRate(PartStateFluid<PartTypeExporterFluid> state) {
+        return GeneralConfig.exporterFluidBaseConsumption;
     }
 }

--- a/src/main/java/org/cyclops/integratedtunnels/part/PartTypeExporterItem.java
+++ b/src/main/java/org/cyclops/integratedtunnels/part/PartTypeExporterItem.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import org.cyclops.integrateddynamics.api.part.aspect.IAspect;
 import org.cyclops.integrateddynamics.core.part.aspect.AspectRegistry;
 import org.cyclops.integrateddynamics.part.aspect.Aspects;
+import org.cyclops.integratedtunnels.GeneralConfig;
 import org.cyclops.integratedtunnels.core.part.PartTypeTunnelAspects;
 import org.cyclops.integratedtunnels.part.aspect.TunnelAspects;
 
@@ -28,5 +29,10 @@ public class PartTypeExporterItem extends PartTypeTunnelAspects<PartTypeExporter
     @Override
     protected PartStateItem<PartTypeExporterItem> constructDefaultState() {
         return new PartStateItem<PartTypeExporterItem>(Aspects.REGISTRY.getWriteAspects(this).size(), false, true);
+    }
+    
+    @Override
+    public int getConsumptionRate(PartStateItem<PartTypeExporterItem> state) {
+        return GeneralConfig.exporterItemBaseConsumption;
     }
 }

--- a/src/main/java/org/cyclops/integratedtunnels/part/PartTypeExporterWorldBlock.java
+++ b/src/main/java/org/cyclops/integratedtunnels/part/PartTypeExporterWorldBlock.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import org.cyclops.integrateddynamics.api.part.aspect.IAspect;
 import org.cyclops.integrateddynamics.core.part.aspect.AspectRegistry;
 import org.cyclops.integrateddynamics.part.aspect.Aspects;
+import org.cyclops.integratedtunnels.GeneralConfig;
 import org.cyclops.integratedtunnels.core.part.PartTypeTunnelAspectsWorld;
 import org.cyclops.integratedtunnels.part.aspect.TunnelAspects;
 
@@ -29,5 +30,10 @@ public class PartTypeExporterWorldBlock extends PartTypeTunnelAspectsWorld<PartT
     @Override
     protected PartStateWorld<PartTypeExporterWorldBlock> constructDefaultState() {
         return new PartStateWorld<PartTypeExporterWorldBlock>(Aspects.REGISTRY.getWriteAspects(this).size());
+    }
+    
+    @Override
+    public int getConsumptionRate(PartStateWorld<PartTypeExporterWorldBlock> state) {
+        return state.hasVariable() ? GeneralConfig.exporterWorldBlockBaseConsumptionEnabled : GeneralConfig.exporterWorldBlockBaseConsumptionDisabled;
     }
 }

--- a/src/main/java/org/cyclops/integratedtunnels/part/PartTypeExporterWorldEnergy.java
+++ b/src/main/java/org/cyclops/integratedtunnels/part/PartTypeExporterWorldEnergy.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import org.cyclops.integrateddynamics.api.part.aspect.IAspect;
 import org.cyclops.integrateddynamics.core.part.aspect.AspectRegistry;
 import org.cyclops.integrateddynamics.part.aspect.Aspects;
+import org.cyclops.integratedtunnels.GeneralConfig;
 import org.cyclops.integratedtunnels.core.part.PartTypeTunnelAspectsWorld;
 import org.cyclops.integratedtunnels.part.aspect.TunnelAspects;
 
@@ -23,5 +24,10 @@ public class PartTypeExporterWorldEnergy extends PartTypeTunnelAspectsWorld<Part
     @Override
     protected PartStateWorld<PartTypeExporterWorldEnergy> constructDefaultState() {
         return new PartStateWorld<PartTypeExporterWorldEnergy>(Aspects.REGISTRY.getWriteAspects(this).size());
+    }
+    
+    @Override
+    public int getConsumptionRate(PartStateWorld<PartTypeExporterWorldEnergy> state) {
+        return state.hasVariable() ? GeneralConfig.exporterWorldEnergyBaseConsumptionEnabled : GeneralConfig.exporterWorldEnergyBaseConsumptionDisabled;
     }
 }

--- a/src/main/java/org/cyclops/integratedtunnels/part/PartTypeExporterWorldFluid.java
+++ b/src/main/java/org/cyclops/integratedtunnels/part/PartTypeExporterWorldFluid.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import org.cyclops.integrateddynamics.api.part.aspect.IAspect;
 import org.cyclops.integrateddynamics.core.part.aspect.AspectRegistry;
 import org.cyclops.integrateddynamics.part.aspect.Aspects;
+import org.cyclops.integratedtunnels.GeneralConfig;
 import org.cyclops.integratedtunnels.core.part.PartTypeTunnelAspectsWorld;
 import org.cyclops.integratedtunnels.part.aspect.TunnelAspects;
 
@@ -33,5 +34,10 @@ public class PartTypeExporterWorldFluid extends PartTypeTunnelAspectsWorld<PartT
     @Override
     protected PartStateWorld<PartTypeExporterWorldFluid> constructDefaultState() {
         return new PartStateWorld<PartTypeExporterWorldFluid>(Aspects.REGISTRY.getWriteAspects(this).size());
+    }
+    
+    @Override
+    public int getConsumptionRate(PartStateWorld<PartTypeExporterWorldFluid> state) {
+        return state.hasVariable() ? GeneralConfig.exporterWorldFluidBaseConsumptionEnabled : GeneralConfig.exporterWorldFluidBaseConsumptionDisabled;
     }
 }

--- a/src/main/java/org/cyclops/integratedtunnels/part/PartTypeExporterWorldItem.java
+++ b/src/main/java/org/cyclops/integratedtunnels/part/PartTypeExporterWorldItem.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import org.cyclops.integrateddynamics.api.part.aspect.IAspect;
 import org.cyclops.integrateddynamics.core.part.aspect.AspectRegistry;
 import org.cyclops.integrateddynamics.part.aspect.Aspects;
+import org.cyclops.integratedtunnels.GeneralConfig;
 import org.cyclops.integratedtunnels.core.part.PartTypeTunnelAspectsWorld;
 import org.cyclops.integratedtunnels.part.aspect.TunnelAspects;
 
@@ -34,5 +35,10 @@ public class PartTypeExporterWorldItem extends PartTypeTunnelAspectsWorld<PartTy
     @Override
     protected PartStateWorld<PartTypeExporterWorldItem> constructDefaultState() {
         return new PartStateWorld<PartTypeExporterWorldItem>(Aspects.REGISTRY.getWriteAspects(this).size());
+    }
+    
+    @Override
+    public int getConsumptionRate(PartStateWorld<PartTypeExporterWorldItem> state) {
+        return state.hasVariable() ? GeneralConfig.exporterWorldItemBaseConsumptionEnabled : GeneralConfig.exporterWorldItemBaseConsumptionDisabled;
     }
 }

--- a/src/main/java/org/cyclops/integratedtunnels/part/PartTypeImporterEnergy.java
+++ b/src/main/java/org/cyclops/integratedtunnels/part/PartTypeImporterEnergy.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import org.cyclops.integrateddynamics.api.part.aspect.IAspect;
 import org.cyclops.integrateddynamics.core.part.aspect.AspectRegistry;
 import org.cyclops.integrateddynamics.part.aspect.Aspects;
+import org.cyclops.integratedtunnels.GeneralConfig;
 import org.cyclops.integratedtunnels.core.part.PartTypeTunnelAspects;
 import org.cyclops.integratedtunnels.part.aspect.TunnelAspects;
 
@@ -23,5 +24,10 @@ public class PartTypeImporterEnergy extends PartTypeTunnelAspects<PartTypeImport
     @Override
     protected PartStateEnergy<PartTypeImporterEnergy> constructDefaultState() {
         return new PartStateEnergy<PartTypeImporterEnergy>(Aspects.REGISTRY.getWriteAspects(this).size(), true, false);
+    }
+    
+    @Override
+    public int getConsumptionRate(PartStateEnergy<PartTypeImporterEnergy> state) {
+        return GeneralConfig.importerEnergyBaseConsumption;
     }
 }

--- a/src/main/java/org/cyclops/integratedtunnels/part/PartTypeImporterFluid.java
+++ b/src/main/java/org/cyclops/integratedtunnels/part/PartTypeImporterFluid.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import org.cyclops.integrateddynamics.api.part.aspect.IAspect;
 import org.cyclops.integrateddynamics.core.part.aspect.AspectRegistry;
 import org.cyclops.integrateddynamics.part.aspect.Aspects;
+import org.cyclops.integratedtunnels.GeneralConfig;
 import org.cyclops.integratedtunnels.core.part.PartTypeTunnelAspects;
 import org.cyclops.integratedtunnels.part.aspect.TunnelAspects;
 
@@ -27,5 +28,10 @@ public class PartTypeImporterFluid extends PartTypeTunnelAspects<PartTypeImporte
     @Override
     protected PartStateFluid<PartTypeImporterFluid> constructDefaultState() {
         return new PartStateFluid<PartTypeImporterFluid>(Aspects.REGISTRY.getWriteAspects(this).size(), true, false);
+    }
+    
+    @Override
+    public int getConsumptionRate(PartStateFluid<PartTypeImporterFluid> state) {
+        return GeneralConfig.importerFluidBaseConsumption;
     }
 }

--- a/src/main/java/org/cyclops/integratedtunnels/part/PartTypeImporterItem.java
+++ b/src/main/java/org/cyclops/integratedtunnels/part/PartTypeImporterItem.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import org.cyclops.integrateddynamics.api.part.aspect.IAspect;
 import org.cyclops.integrateddynamics.core.part.aspect.AspectRegistry;
 import org.cyclops.integrateddynamics.part.aspect.Aspects;
+import org.cyclops.integratedtunnels.GeneralConfig;
 import org.cyclops.integratedtunnels.core.part.PartTypeTunnelAspects;
 import org.cyclops.integratedtunnels.part.aspect.TunnelAspects;
 
@@ -28,5 +29,10 @@ public class PartTypeImporterItem extends PartTypeTunnelAspects<PartTypeImporter
     @Override
     protected PartStateItem<PartTypeImporterItem> constructDefaultState() {
         return new PartStateItem<PartTypeImporterItem>(Aspects.REGISTRY.getWriteAspects(this).size(), true, false);
+    }
+    
+    @Override
+    public int getConsumptionRate(PartStateItem<PartTypeImporterItem> state) {
+        return GeneralConfig.importerItemBaseConsumption;
     }
 }

--- a/src/main/java/org/cyclops/integratedtunnels/part/PartTypeImporterWorldBlock.java
+++ b/src/main/java/org/cyclops/integratedtunnels/part/PartTypeImporterWorldBlock.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import org.cyclops.integrateddynamics.api.part.aspect.IAspect;
 import org.cyclops.integrateddynamics.core.part.aspect.AspectRegistry;
 import org.cyclops.integrateddynamics.part.aspect.Aspects;
+import org.cyclops.integratedtunnels.GeneralConfig;
 import org.cyclops.integratedtunnels.core.part.PartTypeTunnelAspectsWorld;
 import org.cyclops.integratedtunnels.part.aspect.TunnelAspects;
 
@@ -29,5 +30,10 @@ public class PartTypeImporterWorldBlock extends PartTypeTunnelAspectsWorld<PartT
     @Override
     protected PartStateWorld<PartTypeImporterWorldBlock> constructDefaultState() {
         return new PartStateWorld<PartTypeImporterWorldBlock>(Aspects.REGISTRY.getWriteAspects(this).size());
+    }
+    
+    @Override
+    public int getConsumptionRate(PartStateWorld<PartTypeImporterWorldBlock> state) {
+        return state.hasVariable() ? GeneralConfig.importerWorldBlockBaseConsumptionEnabled : GeneralConfig.importerWorldBlockBaseConsumptionDisabled;
     }
 }

--- a/src/main/java/org/cyclops/integratedtunnels/part/PartTypeImporterWorldEnergy.java
+++ b/src/main/java/org/cyclops/integratedtunnels/part/PartTypeImporterWorldEnergy.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import org.cyclops.integrateddynamics.api.part.aspect.IAspect;
 import org.cyclops.integrateddynamics.core.part.aspect.AspectRegistry;
 import org.cyclops.integrateddynamics.part.aspect.Aspects;
+import org.cyclops.integratedtunnels.GeneralConfig;
 import org.cyclops.integratedtunnels.core.part.PartTypeTunnelAspectsWorld;
 import org.cyclops.integratedtunnels.part.aspect.TunnelAspects;
 
@@ -23,5 +24,10 @@ public class PartTypeImporterWorldEnergy extends PartTypeTunnelAspectsWorld<Part
     @Override
     protected PartStateWorld<PartTypeImporterWorldEnergy> constructDefaultState() {
         return new PartStateWorld<PartTypeImporterWorldEnergy>(Aspects.REGISTRY.getWriteAspects(this).size());
+    }
+    
+    @Override
+    public int getConsumptionRate(PartStateWorld<PartTypeImporterWorldEnergy> state) {
+        return state.hasVariable() ? GeneralConfig.importerWorldEnergyBaseConsumptionEnabled : GeneralConfig.importerWorldEnergyBaseConsumptionDisabled;
     }
 }

--- a/src/main/java/org/cyclops/integratedtunnels/part/PartTypeImporterWorldFluid.java
+++ b/src/main/java/org/cyclops/integratedtunnels/part/PartTypeImporterWorldFluid.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import org.cyclops.integrateddynamics.api.part.aspect.IAspect;
 import org.cyclops.integrateddynamics.core.part.aspect.AspectRegistry;
 import org.cyclops.integrateddynamics.part.aspect.Aspects;
+import org.cyclops.integratedtunnels.GeneralConfig;
 import org.cyclops.integratedtunnels.core.part.PartTypeTunnelAspectsWorld;
 import org.cyclops.integratedtunnels.part.aspect.TunnelAspects;
 
@@ -33,5 +34,10 @@ public class PartTypeImporterWorldFluid extends PartTypeTunnelAspectsWorld<PartT
     @Override
     protected PartStateWorld<PartTypeImporterWorldFluid> constructDefaultState() {
         return new PartStateWorld<PartTypeImporterWorldFluid>(Aspects.REGISTRY.getWriteAspects(this).size());
+    }
+    
+    @Override
+    public int getConsumptionRate(PartStateWorld<PartTypeImporterWorldFluid> state) {
+        return state.hasVariable() ? GeneralConfig.importerWorldFluidBaseConsumptionEnabled : GeneralConfig.importerWorldFluidBaseConsumptionDisabled;
     }
 }

--- a/src/main/java/org/cyclops/integratedtunnels/part/PartTypeImporterWorldItem.java
+++ b/src/main/java/org/cyclops/integratedtunnels/part/PartTypeImporterWorldItem.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import org.cyclops.integrateddynamics.api.part.aspect.IAspect;
 import org.cyclops.integrateddynamics.core.part.aspect.AspectRegistry;
 import org.cyclops.integrateddynamics.part.aspect.Aspects;
+import org.cyclops.integratedtunnels.GeneralConfig;
 import org.cyclops.integratedtunnels.core.part.PartTypeTunnelAspectsWorld;
 import org.cyclops.integratedtunnels.part.aspect.TunnelAspects;
 
@@ -34,5 +35,10 @@ public class PartTypeImporterWorldItem extends PartTypeTunnelAspectsWorld<PartTy
     @Override
     protected PartStateWorld<PartTypeImporterWorldItem> constructDefaultState() {
         return new PartStateWorld<PartTypeImporterWorldItem>(Aspects.REGISTRY.getWriteAspects(this).size());
+    }
+    
+    @Override
+    public int getConsumptionRate(PartStateWorld<PartTypeImporterWorldItem> state) {
+        return state.hasVariable() ? GeneralConfig.importerWorldItemBaseConsumptionEnabled : GeneralConfig.importerWorldItemBaseConsumptionDisabled;
     }
 }

--- a/src/main/java/org/cyclops/integratedtunnels/part/PartTypeInterfaceEnergy.java
+++ b/src/main/java/org/cyclops/integratedtunnels/part/PartTypeInterfaceEnergy.java
@@ -6,8 +6,6 @@ import net.minecraftforge.energy.IEnergyStorage;
 import org.cyclops.integrateddynamics.api.network.IEnergyNetwork;
 import org.cyclops.integrateddynamics.api.part.PartPos;
 import org.cyclops.integrateddynamics.core.helper.EnergyHelpers;
-import org.cyclops.integrateddynamics.core.part.write.PartStateWriterBase;
-import org.cyclops.integrateddynamics.part.PartTypeEffectWriter;
 import org.cyclops.integratedtunnels.Capabilities;
 import org.cyclops.integratedtunnels.GeneralConfig;
 import org.cyclops.integratedtunnels.core.part.PartTypeInterfacePositionedAddon;

--- a/src/main/java/org/cyclops/integratedtunnels/part/PartTypeInterfaceEnergy.java
+++ b/src/main/java/org/cyclops/integratedtunnels/part/PartTypeInterfaceEnergy.java
@@ -6,7 +6,10 @@ import net.minecraftforge.energy.IEnergyStorage;
 import org.cyclops.integrateddynamics.api.network.IEnergyNetwork;
 import org.cyclops.integrateddynamics.api.part.PartPos;
 import org.cyclops.integrateddynamics.core.helper.EnergyHelpers;
+import org.cyclops.integrateddynamics.core.part.write.PartStateWriterBase;
+import org.cyclops.integrateddynamics.part.PartTypeEffectWriter;
 import org.cyclops.integratedtunnels.Capabilities;
+import org.cyclops.integratedtunnels.GeneralConfig;
 import org.cyclops.integratedtunnels.core.part.PartTypeInterfacePositionedAddon;
 
 /**
@@ -36,6 +39,11 @@ public class PartTypeInterfaceEnergy extends PartTypeInterfacePositionedAddon<IE
     @Override
     protected PartTypeInterfaceEnergy.State constructDefaultState() {
         return new PartTypeInterfaceEnergy.State();
+    }
+    
+    @Override
+    public int getConsumptionRate(State state) {
+        return GeneralConfig.interfaceEnergyBaseConsumption;
     }
 
     public static class State extends PartTypeInterfacePositionedAddon.State<PartTypeInterfaceEnergy, IEnergyNetwork, IEnergyStorage> implements IEnergyStorage {

--- a/src/main/java/org/cyclops/integratedtunnels/part/PartTypeInterfaceFluid.java
+++ b/src/main/java/org/cyclops/integratedtunnels/part/PartTypeInterfaceFluid.java
@@ -5,12 +5,10 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidTankProperties;
-
 import org.cyclops.integratedtunnels.GeneralConfig;
 import org.cyclops.integratedtunnels.api.network.IFluidNetwork;
 import org.cyclops.integratedtunnels.capability.network.FluidNetworkConfig;
 import org.cyclops.integratedtunnels.core.part.PartTypeInterfacePositionedAddon;
-import org.cyclops.integratedtunnels.part.PartTypeInterfaceEnergy.State;
 
 import javax.annotation.Nullable;
 

--- a/src/main/java/org/cyclops/integratedtunnels/part/PartTypeInterfaceFluid.java
+++ b/src/main/java/org/cyclops/integratedtunnels/part/PartTypeInterfaceFluid.java
@@ -5,9 +5,12 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidTankProperties;
+
+import org.cyclops.integratedtunnels.GeneralConfig;
 import org.cyclops.integratedtunnels.api.network.IFluidNetwork;
 import org.cyclops.integratedtunnels.capability.network.FluidNetworkConfig;
 import org.cyclops.integratedtunnels.core.part.PartTypeInterfacePositionedAddon;
+import org.cyclops.integratedtunnels.part.PartTypeInterfaceEnergy.State;
 
 import javax.annotation.Nullable;
 
@@ -33,6 +36,11 @@ public class PartTypeInterfaceFluid extends PartTypeInterfacePositionedAddon<IFl
     @Override
     protected PartTypeInterfaceFluid.State constructDefaultState() {
         return new PartTypeInterfaceFluid.State();
+    }
+    
+    @Override
+    public int getConsumptionRate(State state) {
+        return GeneralConfig.interfaceFluidBaseConsumption;
     }
 
     public static class State extends PartTypeInterfacePositionedAddon.State<PartTypeInterfaceFluid, IFluidNetwork, IFluidHandler> implements IFluidHandler {

--- a/src/main/java/org/cyclops/integratedtunnels/part/PartTypeInterfaceItem.java
+++ b/src/main/java/org/cyclops/integratedtunnels/part/PartTypeInterfaceItem.java
@@ -7,9 +7,11 @@ import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 import org.cyclops.commoncapabilities.api.capability.itemhandler.ISlotlessItemHandler;
 import org.cyclops.integratedtunnels.Capabilities;
+import org.cyclops.integratedtunnels.GeneralConfig;
 import org.cyclops.integratedtunnels.api.network.IItemNetwork;
 import org.cyclops.integratedtunnels.capability.network.ItemNetworkConfig;
 import org.cyclops.integratedtunnels.core.part.PartTypeInterfacePositionedAddon;
+import org.cyclops.integratedtunnels.part.PartTypeInterfaceFluid.State;
 
 import javax.annotation.Nonnull;
 import java.util.Iterator;
@@ -36,6 +38,11 @@ public class PartTypeInterfaceItem extends PartTypeInterfacePositionedAddon<IIte
     @Override
     protected PartTypeInterfaceItem.State constructDefaultState() {
         return new PartTypeInterfaceItem.State();
+    }
+    
+    @Override
+    public int getConsumptionRate(State state) {
+        return GeneralConfig.interfaceItemBaseConsumption;
     }
 
     public static class State extends PartTypeInterfacePositionedAddon.State<PartTypeInterfaceItem, IItemNetwork, IItemHandler> implements IItemHandler, ISlotlessItemHandler {

--- a/src/main/java/org/cyclops/integratedtunnels/part/PartTypeInterfaceItem.java
+++ b/src/main/java/org/cyclops/integratedtunnels/part/PartTypeInterfaceItem.java
@@ -11,7 +11,6 @@ import org.cyclops.integratedtunnels.GeneralConfig;
 import org.cyclops.integratedtunnels.api.network.IItemNetwork;
 import org.cyclops.integratedtunnels.capability.network.ItemNetworkConfig;
 import org.cyclops.integratedtunnels.core.part.PartTypeInterfacePositionedAddon;
-import org.cyclops.integratedtunnels.part.PartTypeInterfaceFluid.State;
 
 import javax.annotation.Nonnull;
 import java.util.Iterator;

--- a/src/main/java/org/cyclops/integratedtunnels/part/PartTypePlayerSimulator.java
+++ b/src/main/java/org/cyclops/integratedtunnels/part/PartTypePlayerSimulator.java
@@ -7,6 +7,7 @@ import org.cyclops.integrateddynamics.api.part.PartTarget;
 import org.cyclops.integrateddynamics.api.part.aspect.IAspect;
 import org.cyclops.integrateddynamics.core.part.aspect.AspectRegistry;
 import org.cyclops.integrateddynamics.part.aspect.Aspects;
+import org.cyclops.integratedtunnels.GeneralConfig;
 import org.cyclops.integratedtunnels.core.part.PartTypeTunnelAspectsWorld;
 import org.cyclops.integratedtunnels.part.aspect.TunnelAspects;
 
@@ -35,7 +36,7 @@ public class PartTypePlayerSimulator extends PartTypeTunnelAspectsWorld<PartType
 
     @Override
     public int getConsumptionRate(PartStatePlayerSimulator state) {
-        return state.hasVariable() ? 64 : super.getConsumptionRate(state);
+        return state.hasVariable() ? GeneralConfig.playerSimulatorBaseConsumptionEnabled : GeneralConfig.playerSimulatorBaseConsumptionDisabled;
     }
 
     @Override

--- a/src/main/resources/assets/integratedtunnels/lang/en_us.lang
+++ b/src/main/resources/assets/integratedtunnels/lang/en_us.lang
@@ -395,6 +395,35 @@ config.integratedtunnels.general.inventoryUnchangedTickTimeout=Timeout for uncha
 config.integratedtunnels.general.version=Version
 config.integratedtunnels.general.versionChecker=Version check
 
+## General settings
+config.integratedtunnels.general.exporterEnergyBaseConsumption=Energy exporter base consumption
+config.integratedtunnels.general.exporterFluidBaseConsumption=Fluid exporter base consumption
+config.integratedtunnels.general.exporterItemBaseConsumption=Item exporter base consumption
+config.integratedtunnels.general.exporterWorldBlockBaseConsumptionEnabled=World block exporter base consumption (enabled)
+config.integratedtunnels.general.exporterWorldBlockBaseConsumptionDisabled=World block exporter base consumption (disabled)
+config.integratedtunnels.general.exporterWorldEnergyBaseConsumptionEnabled=World energy exporter base consumption (enabled)
+config.integratedtunnels.general.exporterWorldEnergyBaseConsumptionDisabled=World energy exporter base consumption (disabled)
+config.integratedtunnels.general.exporterWorldFluidBaseConsumptionEnabled=World fluid exporter base consumption (enabled)
+config.integratedtunnels.general.exporterWorldFluidBaseConsumptionDisabled=World fluid exporter base consumption (disabled)
+config.integratedtunnels.general.exporterWorldItemBaseConsumptionEnabled=World item exporter base consumption (enabled)
+config.integratedtunnels.general.exporterWorldItemBaseConsumptionDisabled=World item exporter base consumption (disabled)
+config.integratedtunnels.general.importerEnergyBaseConsumption=Energy importer base consumption
+config.integratedtunnels.general.importerFluidBaseConsumption=Fluid importer base consumption
+config.integratedtunnels.general.importerItemBaseConsumption=Item importer base consumption
+config.integratedtunnels.general.importerWorldBlockBaseConsumptionEnabled=World block importer base consumption (enabled)
+config.integratedtunnels.general.importerWorldBlockBaseConsumptionDisabled=World block importer base consumption (disabled)
+config.integratedtunnels.general.importerWorldEnergyBaseConsumptionEnabled=World energy importer base consumption (enabled)
+config.integratedtunnels.general.importerWorldEnergyBaseConsumptionDisabled=World energy importer base consumption (disabled)
+config.integratedtunnels.general.importerWorldFluidBaseConsumptionEnabled=World fluid importer base consumption (enabled)
+config.integratedtunnels.general.importerWorldFluidBaseConsumptionDisabled=World fluid importer base consumption (disabled)
+config.integratedtunnels.general.importerWorldItemBaseConsumptionEnabled=World item importer base consumption (enabled)
+config.integratedtunnels.general.importerWorldItemBaseConsumptionDisabled=World item importer base consumption (disabled)
+config.integratedtunnels.general.interfaceEnergyBaseConsumption=Energy interface base consumption
+config.integratedtunnels.general.interfaceFluidBaseConsumption=Fluid interface base consumption
+config.integratedtunnels.general.interfaceItemBaseConsumption=Item interface base consumption
+config.integratedtunnels.general.playerSimulatorBaseConsumptionEnabled=Player simulator base consumption (enabled)
+config.integratedtunnels.general.playerSimulatorBaseConsumptionDisabled=Player simulator base consumption (disabled)
+
 ## Mod compatibility settings
 config.integratedtunnels.tesla=Tesla
 


### PR DESCRIPTION
I made separate enabled and disabled config options for each part that previously had different consumption behavior when enabled and disabled.