### PR TITLE
Add "Entity Inventory" option to entity aspects on world item tunnels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ repo/*
 *.ipr
 *.iws
 out/*
+run*.launch
 keystore.jks
 
 # Ignore mac-specific file(s)

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
         maven {
             name = "forge"
-            url = "http://files.minecraftforge.net/maven"
+            url = "https://maven.minecraftforge.net/"
         }
     }
     dependencies {
@@ -23,6 +23,7 @@ plugins {
 
 apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'idea'
+apply plugin: 'eclipse'
 apply plugin: 'maven'
 apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'jacoco'

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 mod_version=1.8.9
 minecraft_version=1.16.5
-forge_version=36.2.5
+forge_version=36.2.34
 mcp_mappings_channel=snapshot
 mcp_mappings_version=20201028-1.16.3
 cyclopscore_version=1.11.6-64

--- a/src/main/java/org/cyclops/integratedtunnels/IntegratedTunnels.java
+++ b/src/main/java/org/cyclops/integratedtunnels/IntegratedTunnels.java
@@ -22,6 +22,7 @@ import org.cyclops.integrateddynamics.core.part.aspect.AspectRegistry;
 import org.cyclops.integrateddynamics.infobook.OnTheDynamicsOfIntegrationBook;
 import org.cyclops.integratedtunnels.api.world.IBlockBreakHandlerRegistry;
 import org.cyclops.integratedtunnels.api.world.IBlockPlaceHandlerRegistry;
+import org.cyclops.integratedtunnels.api.world.IEntityInventoryTypeRegistry;
 import org.cyclops.integratedtunnels.capability.ingredient.TunnelIngredientComponentCapabilities;
 import org.cyclops.integratedtunnels.capability.network.FluidNetworkConfig;
 import org.cyclops.integratedtunnels.capability.network.ItemNetworkConfig;
@@ -31,6 +32,8 @@ import org.cyclops.integratedtunnels.core.world.BlockBreakHandlerRegistry;
 import org.cyclops.integratedtunnels.core.world.BlockBreakHandlers;
 import org.cyclops.integratedtunnels.core.world.BlockBreakPlaceRegistry;
 import org.cyclops.integratedtunnels.core.world.BlockPlaceHandlers;
+import org.cyclops.integratedtunnels.core.world.EntityInventoryTypeRegistry;
+import org.cyclops.integratedtunnels.core.world.EntityInventoryTypes;
 import org.cyclops.integratedtunnels.item.ItemDummyPickAxeConfig;
 import org.cyclops.integratedtunnels.part.PartTypes;
 import org.cyclops.integratedtunnels.part.aspect.TunnelAspects;
@@ -57,6 +60,7 @@ public class IntegratedTunnels extends ModBaseVersionable<IntegratedTunnels> {
         // Registries
         getRegistryManager().addRegistry(IBlockBreakHandlerRegistry.class, BlockBreakHandlerRegistry.getInstance());
         getRegistryManager().addRegistry(IBlockPlaceHandlerRegistry.class, BlockBreakPlaceRegistry.getInstance());
+        getRegistryManager().addRegistry(IEntityInventoryTypeRegistry.class, EntityInventoryTypeRegistry.getInstance());
 
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onRegistriesCreate);
     }
@@ -67,6 +71,7 @@ public class IntegratedTunnels extends ModBaseVersionable<IntegratedTunnels> {
         PartTypes.load();
         BlockBreakHandlers.load();
         BlockPlaceHandlers.load();
+        EntityInventoryTypes.load();
     }
 
     @Override

--- a/src/main/java/org/cyclops/integratedtunnels/IntegratedTunnels.java
+++ b/src/main/java/org/cyclops/integratedtunnels/IntegratedTunnels.java
@@ -17,11 +17,11 @@ import org.cyclops.cyclopscore.init.ModBaseVersionable;
 import org.cyclops.cyclopscore.proxy.IClientProxy;
 import org.cyclops.cyclopscore.proxy.ICommonProxy;
 import org.cyclops.integrateddynamics.IntegratedDynamics;
-import org.cyclops.integrateddynamics.api.part.aspect.IAspect;
 import org.cyclops.integrateddynamics.core.part.aspect.AspectRegistry;
 import org.cyclops.integrateddynamics.infobook.OnTheDynamicsOfIntegrationBook;
 import org.cyclops.integratedtunnels.api.world.IBlockBreakHandlerRegistry;
 import org.cyclops.integratedtunnels.api.world.IBlockPlaceHandlerRegistry;
+import org.cyclops.integratedtunnels.api.world.IEntityIItemTargetProxyRegistry;
 import org.cyclops.integratedtunnels.api.world.IEntityInventoryTypeRegistry;
 import org.cyclops.integratedtunnels.capability.ingredient.TunnelIngredientComponentCapabilities;
 import org.cyclops.integratedtunnels.capability.network.FluidNetworkConfig;
@@ -32,6 +32,8 @@ import org.cyclops.integratedtunnels.core.world.BlockBreakHandlerRegistry;
 import org.cyclops.integratedtunnels.core.world.BlockBreakHandlers;
 import org.cyclops.integratedtunnels.core.world.BlockBreakPlaceRegistry;
 import org.cyclops.integratedtunnels.core.world.BlockPlaceHandlers;
+import org.cyclops.integratedtunnels.core.world.EntityIItemTargetProxies;
+import org.cyclops.integratedtunnels.core.world.EntityIItemTargetProxyRegistry;
 import org.cyclops.integratedtunnels.core.world.EntityInventoryTypeRegistry;
 import org.cyclops.integratedtunnels.core.world.EntityInventoryTypes;
 import org.cyclops.integratedtunnels.item.ItemDummyPickAxeConfig;
@@ -61,6 +63,7 @@ public class IntegratedTunnels extends ModBaseVersionable<IntegratedTunnels> {
         getRegistryManager().addRegistry(IBlockBreakHandlerRegistry.class, BlockBreakHandlerRegistry.getInstance());
         getRegistryManager().addRegistry(IBlockPlaceHandlerRegistry.class, BlockBreakPlaceRegistry.getInstance());
         getRegistryManager().addRegistry(IEntityInventoryTypeRegistry.class, EntityInventoryTypeRegistry.getInstance());
+        getRegistryManager().addRegistry(IEntityIItemTargetProxyRegistry.class, EntityIItemTargetProxyRegistry.getInstance());
 
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::onRegistriesCreate);
     }
@@ -72,6 +75,7 @@ public class IntegratedTunnels extends ModBaseVersionable<IntegratedTunnels> {
         BlockBreakHandlers.load();
         BlockPlaceHandlers.load();
         EntityInventoryTypes.load();
+        EntityIItemTargetProxies.load();
     }
 
     @Override

--- a/src/main/java/org/cyclops/integratedtunnels/Reference.java
+++ b/src/main/java/org/cyclops/integratedtunnels/Reference.java
@@ -2,6 +2,8 @@ package org.cyclops.integratedtunnels;
 
 import org.cyclops.cyclopscore.helper.MinecraftHelpers;
 
+import net.minecraft.util.Direction;
+
 /**
  * Class that can hold basic static things that are better not hard-coded
  * like mod details, texture paths, ID's...
@@ -20,4 +22,8 @@ public class Reference {
     public static final String MOD_FORGE = "forge";
     public static final String MOD_CYCLOPSCORE = "cyclopscore";
     public static final String MOD_INTEGRATEDDYNAMICS = "integrateddynamics";
+    
+    // Entity Inventory Sidings
+    public static final Direction ENTITY_ARMOR_SIDE = Direction.NORTH;
+    public static final Direction ENTITY_INVENTORY_SIDE = Direction.UP;
 }

--- a/src/main/java/org/cyclops/integratedtunnels/api/world/EntityInventoryTypeBase.java
+++ b/src/main/java/org/cyclops/integratedtunnels/api/world/EntityInventoryTypeBase.java
@@ -1,0 +1,26 @@
+package org.cyclops.integratedtunnels.api.world;
+
+import javax.annotation.Nonnull;
+
+/**
+ * An entity inventory type.
+ * For example: armor slots, inventory slots, ender chest.
+ * Other mods may add extra inventory types.
+ * 
+ * Effectively an enum key; used as entries in a registry.
+ * 
+ * @author met4000
+ */
+public abstract class EntityInventoryTypeBase {
+    
+    @Nonnull
+    public abstract String getName(); // TODO allow for localisation
+    
+    @Override
+    public final boolean equals(Object o) {
+        if (o == null) return false;
+        if (!(o instanceof EntityInventoryTypeBase)) return false;
+        return getName().equals(((EntityInventoryTypeBase)o).getName());
+    }
+    
+}

--- a/src/main/java/org/cyclops/integratedtunnels/api/world/IEntityIItemTargetProxy.java
+++ b/src/main/java/org/cyclops/integratedtunnels/api/world/IEntityIItemTargetProxy.java
@@ -1,0 +1,33 @@
+package org.cyclops.integratedtunnels.api.world;
+
+import javax.annotation.Nullable;
+
+import org.cyclops.integrateddynamics.api.network.INetwork;
+import org.cyclops.integrateddynamics.api.part.PartTarget;
+import org.cyclops.integrateddynamics.api.part.aspect.property.IAspectProperties;
+import org.cyclops.integratedtunnels.core.part.PartStateRoundRobin;
+import org.cyclops.integratedtunnels.core.predicate.IngredientPredicate;
+import org.cyclops.integratedtunnels.part.aspect.IItemTarget;
+import org.cyclops.integratedtunnels.part.aspect.ITunnelTransfer;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Direction;
+
+/**
+ * Proxy that can produce an IItemTarget for an Entity.
+ * @author met4000
+ */
+public interface IEntityIItemTargetProxy {
+    
+    public boolean shouldApply(ITunnelTransfer transfer, INetwork network,
+            @Nullable Entity entity, Direction side, int slot,
+            IngredientPredicate<ItemStack, Integer> itemStackMatcher, PartTarget partTarget,
+            IAspectProperties properties, @Nullable PartStateRoundRobin<?> partState);
+    
+    public IItemTarget evaluate(ITunnelTransfer transfer, INetwork network,
+            @Nullable Entity entity, Direction side, int slot,
+            IngredientPredicate<ItemStack, Integer> itemStackMatcher, PartTarget partTarget,
+            IAspectProperties properties, @Nullable PartStateRoundRobin<?> partState);
+    
+}

--- a/src/main/java/org/cyclops/integratedtunnels/api/world/IEntityIItemTargetProxyRegistry.java
+++ b/src/main/java/org/cyclops/integratedtunnels/api/world/IEntityIItemTargetProxyRegistry.java
@@ -1,0 +1,38 @@
+package org.cyclops.integratedtunnels.api.world;
+
+import java.util.Collection;
+
+import javax.annotation.Nullable;
+
+import org.cyclops.cyclopscore.init.IRegistry;
+import org.cyclops.integrateddynamics.api.network.INetwork;
+import org.cyclops.integrateddynamics.api.part.PartTarget;
+import org.cyclops.integrateddynamics.api.part.aspect.property.IAspectProperties;
+import org.cyclops.integratedtunnels.core.part.PartStateRoundRobin;
+import org.cyclops.integratedtunnels.core.predicate.IngredientPredicate;
+import org.cyclops.integratedtunnels.part.aspect.ITunnelTransfer;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Direction;
+
+/**
+ * A registry for entity IItemTarget proxies.
+ * @author met4000
+ */
+public interface IEntityIItemTargetProxyRegistry extends IRegistry {
+
+    /**
+     * Multiple handlers may exist that return `true` for #shouldApply; the first one found should be used.
+     */
+    public IEntityIItemTargetProxy register(IEntityIItemTargetProxy proxy);
+
+    public Collection<IEntityIItemTargetProxy> getProxies();
+
+    @Nullable
+    public IEntityIItemTargetProxy getHandler(ITunnelTransfer transfer, INetwork network, @Nullable Entity entity,
+            Direction side, int slot, IngredientPredicate<ItemStack, Integer> itemStackMatcher, PartTarget partTarget,
+            IAspectProperties properties, @Nullable PartStateRoundRobin<?> partState);
+
+}
+

--- a/src/main/java/org/cyclops/integratedtunnels/api/world/IEntityIItemTargetProxyRegistry.java
+++ b/src/main/java/org/cyclops/integratedtunnels/api/world/IEntityIItemTargetProxyRegistry.java
@@ -22,9 +22,7 @@ import net.minecraft.util.Direction;
  */
 public interface IEntityIItemTargetProxyRegistry extends IRegistry {
 
-    /**
-     * Multiple handlers may exist that return `true` for #shouldApply; the first one found should be used.
-     */
+    // Multiple handlers may exist that return `true` for #shouldApply; the first one found should be used.
     public IEntityIItemTargetProxy register(IEntityIItemTargetProxy proxy);
 
     public Collection<IEntityIItemTargetProxy> getProxies();

--- a/src/main/java/org/cyclops/integratedtunnels/api/world/IEntityInventoryTypeRegistry.java
+++ b/src/main/java/org/cyclops/integratedtunnels/api/world/IEntityInventoryTypeRegistry.java
@@ -1,0 +1,17 @@
+package org.cyclops.integratedtunnels.api.world;
+
+import java.util.Collection;
+
+import org.cyclops.cyclopscore.init.IRegistry;
+
+/**
+ * Collection of IEntityInventoryTypes.
+ * @author met4000
+ */
+public interface IEntityInventoryTypeRegistry extends IRegistry {
+    
+    public EntityInventoryTypeBase register(EntityInventoryTypeBase type);
+
+    public Collection<EntityInventoryTypeBase> getTypes();
+    
+}

--- a/src/main/java/org/cyclops/integratedtunnels/core/world/EntityIItemTargetProxies.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/world/EntityIItemTargetProxies.java
@@ -1,0 +1,42 @@
+package org.cyclops.integratedtunnels.core.world;
+
+import org.cyclops.integrateddynamics.api.network.INetwork;
+import org.cyclops.integrateddynamics.api.part.PartTarget;
+import org.cyclops.integrateddynamics.api.part.aspect.property.IAspectProperties;
+import org.cyclops.integratedtunnels.IntegratedTunnels;
+import org.cyclops.integratedtunnels.api.world.IEntityIItemTargetProxyRegistry;
+import org.cyclops.integratedtunnels.core.part.PartStateRoundRobin;
+import org.cyclops.integratedtunnels.core.predicate.IngredientPredicate;
+import org.cyclops.integratedtunnels.part.aspect.IItemTarget;
+import org.cyclops.integratedtunnels.part.aspect.ITunnelTransfer;
+import org.cyclops.integratedtunnels.part.aspect.ItemTargetCapabilityProvider;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Direction;
+
+/**
+ * Collection of Entity IItemTarget proxies.
+ * @author met4000
+ */
+public class EntityIItemTargetProxies {
+    
+    public static final IEntityIItemTargetProxyRegistry REGISTRY = IntegratedTunnels._instance.getRegistryManager()
+            .getRegistry(IEntityIItemTargetProxyRegistry.class);
+    
+    public static void load() {
+        REGISTRY.register(new EntityIItemTargetProxyInventoryTypeBase(EntityInventoryTypes.SIDED) {
+            @Override
+            public IItemTarget evaluate(ITunnelTransfer transfer, INetwork network, Entity entity, Direction side, int slot,
+                    IngredientPredicate<ItemStack, Integer> itemStackMatcher, PartTarget partTarget,
+                    IAspectProperties properties, PartStateRoundRobin<?> partState) {
+                return new ItemTargetCapabilityProvider(transfer, network, entity, side,
+                        slot, itemStackMatcher, partTarget, properties, partState);
+            }
+        });
+        
+        REGISTRY.register(new EntityIItemTargetProxySided(EntityInventoryTypes.ARMOR, EntityInventoryTypes.ARMOR_SIDE));
+        REGISTRY.register(new EntityIItemTargetProxySided(EntityInventoryTypes.INVENTORY, EntityInventoryTypes.INVENTORY_SIDE));
+    }
+    
+}

--- a/src/main/java/org/cyclops/integratedtunnels/core/world/EntityIItemTargetProxies.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/world/EntityIItemTargetProxies.java
@@ -4,6 +4,7 @@ import org.cyclops.integrateddynamics.api.network.INetwork;
 import org.cyclops.integrateddynamics.api.part.PartTarget;
 import org.cyclops.integrateddynamics.api.part.aspect.property.IAspectProperties;
 import org.cyclops.integratedtunnels.IntegratedTunnels;
+import org.cyclops.integratedtunnels.Reference;
 import org.cyclops.integratedtunnels.api.world.IEntityIItemTargetProxyRegistry;
 import org.cyclops.integratedtunnels.core.part.PartStateRoundRobin;
 import org.cyclops.integratedtunnels.core.predicate.IngredientPredicate;
@@ -35,8 +36,8 @@ public class EntityIItemTargetProxies {
             }
         });
         
-        REGISTRY.register(new EntityIItemTargetProxySided(EntityInventoryTypes.ARMOR, EntityInventoryTypes.ARMOR_SIDE));
-        REGISTRY.register(new EntityIItemTargetProxySided(EntityInventoryTypes.INVENTORY, EntityInventoryTypes.INVENTORY_SIDE));
+        REGISTRY.register(new EntityIItemTargetProxySided(EntityInventoryTypes.ARMOR, Reference.ENTITY_ARMOR_SIDE));
+        REGISTRY.register(new EntityIItemTargetProxySided(EntityInventoryTypes.INVENTORY, Reference.ENTITY_INVENTORY_SIDE));
     }
     
 }

--- a/src/main/java/org/cyclops/integratedtunnels/core/world/EntityIItemTargetProxyBase.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/world/EntityIItemTargetProxyBase.java
@@ -1,0 +1,23 @@
+package org.cyclops.integratedtunnels.core.world;
+
+import org.cyclops.integratedtunnels.IntegratedTunnels;
+import org.cyclops.integratedtunnels.api.world.EntityInventoryTypeBase;
+import org.cyclops.integratedtunnels.api.world.IEntityIItemTargetProxy;
+import org.cyclops.integratedtunnels.api.world.IEntityInventoryTypeRegistry;
+
+/**
+ * Registers the IEntityInventoryType with the EntityInventoryTypeRegistry.
+ * @author met4000
+ */
+public abstract class EntityIItemTargetProxyBase implements IEntityIItemTargetProxy {
+    
+    private static final IEntityInventoryTypeRegistry REGISTRY = IntegratedTunnels._instance.getRegistryManager()
+            .getRegistry(IEntityInventoryTypeRegistry.class);
+    
+    protected final EntityInventoryTypeBase inventoryType;
+
+    public EntityIItemTargetProxyBase(EntityInventoryTypeBase inventoryType) {
+        this.inventoryType = REGISTRY.register(inventoryType);
+    }
+
+}

--- a/src/main/java/org/cyclops/integratedtunnels/core/world/EntityIItemTargetProxyInventoryTypeBase.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/world/EntityIItemTargetProxyInventoryTypeBase.java
@@ -1,0 +1,33 @@
+package org.cyclops.integratedtunnels.core.world;
+
+import org.cyclops.integrateddynamics.api.network.INetwork;
+import org.cyclops.integrateddynamics.api.part.PartTarget;
+import org.cyclops.integrateddynamics.api.part.aspect.property.IAspectProperties;
+import org.cyclops.integratedtunnels.api.world.EntityInventoryTypeBase;
+import org.cyclops.integratedtunnels.core.part.PartStateRoundRobin;
+import org.cyclops.integratedtunnels.core.predicate.IngredientPredicate;
+import org.cyclops.integratedtunnels.part.aspect.ITunnelTransfer;
+import org.cyclops.integratedtunnels.part.aspect.TunnelAspectWriteBuilders.World;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Direction;
+
+/**
+ * An IItemTarget proxy to access a sided entity.
+ * @author met4000
+ */
+public abstract class EntityIItemTargetProxyInventoryTypeBase extends EntityIItemTargetProxyBase {
+
+    public EntityIItemTargetProxyInventoryTypeBase(EntityInventoryTypeBase inventoryType) {
+        super(inventoryType);
+    }
+
+    @Override
+    public boolean shouldApply(ITunnelTransfer transfer, INetwork network, Entity entity, Direction side, int slot,
+            IngredientPredicate<ItemStack, Integer> itemStackMatcher, PartTarget partTarget,
+            IAspectProperties properties, PartStateRoundRobin<?> partState) {
+        return inventoryType.getName().equals(properties.getValue(World.PROPERTY_ENTITYINVENTORY).getRawValue());
+    }
+
+}

--- a/src/main/java/org/cyclops/integratedtunnels/core/world/EntityIItemTargetProxyRegistry.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/world/EntityIItemTargetProxyRegistry.java
@@ -1,0 +1,63 @@
+package org.cyclops.integratedtunnels.core.world;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+
+import javax.annotation.Nullable;
+
+import org.cyclops.integrateddynamics.api.network.INetwork;
+import org.cyclops.integrateddynamics.api.part.PartTarget;
+import org.cyclops.integrateddynamics.api.part.aspect.property.IAspectProperties;
+import org.cyclops.integratedtunnels.api.world.IEntityIItemTargetProxy;
+import org.cyclops.integratedtunnels.api.world.IEntityIItemTargetProxyRegistry;
+import org.cyclops.integratedtunnels.core.part.PartStateRoundRobin;
+import org.cyclops.integratedtunnels.core.predicate.IngredientPredicate;
+import org.cyclops.integratedtunnels.part.aspect.ITunnelTransfer;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Direction;
+
+/**
+ * Implementation of {@link IEntityIItemTargetProxyRegistry}
+ * @author met4000
+ */
+public class EntityIItemTargetProxyRegistry implements IEntityIItemTargetProxyRegistry {
+    
+    private static EntityIItemTargetProxyRegistry INSTANCE = new EntityIItemTargetProxyRegistry();
+    
+    // linked list used for constant append time
+    private final Collection<IEntityIItemTargetProxy> proxies = new LinkedList<IEntityIItemTargetProxy>();
+
+    private EntityIItemTargetProxyRegistry() {}
+    
+    public static EntityIItemTargetProxyRegistry getInstance() {
+        return INSTANCE;
+    }
+    
+    @Override
+    public IEntityIItemTargetProxy register(IEntityIItemTargetProxy proxy) {
+        proxies.add(proxy);
+        return proxy;
+    }
+
+    @Override
+    public Collection<IEntityIItemTargetProxy> getProxies() {
+        return Collections.unmodifiableCollection(proxies);
+    }
+    
+    @Nullable
+    @Override
+    public IEntityIItemTargetProxy getHandler(ITunnelTransfer transfer, INetwork network, @Nullable Entity entity,
+            Direction side, int slot, IngredientPredicate<ItemStack, Integer> itemStackMatcher, PartTarget partTarget,
+            IAspectProperties properties, @Nullable PartStateRoundRobin<?> partState) {
+        for (IEntityIItemTargetProxy proxy : getProxies()) {
+            if (proxy.shouldApply(transfer, network, entity, side, slot, itemStackMatcher, partTarget, properties, partState)) {
+                return proxy;
+            }
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/org/cyclops/integratedtunnels/core/world/EntityIItemTargetProxySided.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/world/EntityIItemTargetProxySided.java
@@ -1,0 +1,42 @@
+package org.cyclops.integratedtunnels.core.world;
+
+import org.cyclops.integrateddynamics.api.network.INetwork;
+import org.cyclops.integrateddynamics.api.part.PartTarget;
+import org.cyclops.integrateddynamics.api.part.aspect.property.IAspectProperties;
+import org.cyclops.integratedtunnels.api.world.EntityInventoryTypeBase;
+import org.cyclops.integratedtunnels.core.part.PartStateRoundRobin;
+import org.cyclops.integratedtunnels.core.predicate.IngredientPredicate;
+import org.cyclops.integratedtunnels.part.aspect.IItemTarget;
+import org.cyclops.integratedtunnels.part.aspect.ITunnelTransfer;
+import org.cyclops.integratedtunnels.part.aspect.ItemTargetCapabilityProvider;
+import org.cyclops.integratedtunnels.part.aspect.TunnelAspectWriteBuilders.World;
+
+import lombok.NonNull;
+import net.minecraft.entity.Entity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Direction;
+
+/**
+ * An IItemTarget proxy to access a sided entity.
+ * Uses the specified side when interacting with the capability provider.
+ * @author met4000
+ */
+public class EntityIItemTargetProxySided extends EntityIItemTargetProxyInventoryTypeBase {
+    
+    @NonNull
+    protected final Direction side;
+    
+    public EntityIItemTargetProxySided(EntityInventoryTypeBase inventoryType, Direction side) {
+        super(inventoryType);
+        this.side = side;
+    }
+
+    @Override
+    public IItemTarget evaluate(ITunnelTransfer transfer, INetwork network, Entity entity, Direction side, int slot,
+            IngredientPredicate<ItemStack, Integer> itemStackMatcher, PartTarget partTarget,
+            IAspectProperties properties, PartStateRoundRobin<?> partState) {
+        return new ItemTargetCapabilityProvider(transfer, network, entity, this.side,
+                slot, itemStackMatcher, partTarget, properties, partState);
+    }
+
+}

--- a/src/main/java/org/cyclops/integratedtunnels/core/world/EntityInventoryType.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/world/EntityInventoryType.java
@@ -1,0 +1,28 @@
+package org.cyclops.integratedtunnels.core.world;
+
+import javax.annotation.Nonnull;
+
+import org.cyclops.integratedtunnels.api.world.EntityInventoryTypeBase;
+
+/**
+ * Implements {@link EntityInventoryTypeBase}
+ * @author met4000
+ */
+public class EntityInventoryType extends EntityInventoryTypeBase {
+    
+    private final String name;
+    
+    public EntityInventoryType(String name) {
+        this.name = name;
+    };
+    
+    public static EntityInventoryType fromString(String name) {
+        return new EntityInventoryType(name);
+    }
+
+    @Override @Nonnull
+    public String getName() {
+        return name;
+    }
+
+}

--- a/src/main/java/org/cyclops/integratedtunnels/core/world/EntityInventoryTypeRegistry.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/world/EntityInventoryTypeRegistry.java
@@ -1,0 +1,38 @@
+package org.cyclops.integratedtunnels.core.world;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+
+import org.cyclops.integratedtunnels.api.world.EntityInventoryTypeBase;
+import org.cyclops.integratedtunnels.api.world.IEntityInventoryTypeRegistry;
+
+/**
+ * Implements {@link IEntityInventoryTypeRegistry}
+ * @author met4000
+ */
+public class EntityInventoryTypeRegistry implements IEntityInventoryTypeRegistry {
+
+    private static EntityInventoryTypeRegistry INSTANCE = new EntityInventoryTypeRegistry();
+    
+    // linked list used for constant append time
+    private final Collection<EntityInventoryTypeBase> types = new LinkedList<EntityInventoryTypeBase>();
+
+    private EntityInventoryTypeRegistry() {}
+    
+    public static EntityInventoryTypeRegistry getInstance() {
+        return INSTANCE;
+    }
+    
+    @Override
+    public EntityInventoryTypeBase register(EntityInventoryTypeBase type) {
+        types.add(type);
+        return type;
+    }
+
+    @Override
+    public Collection<EntityInventoryTypeBase> getTypes() {
+        return Collections.unmodifiableCollection(types);
+    }
+
+}

--- a/src/main/java/org/cyclops/integratedtunnels/core/world/EntityInventoryTypes.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/world/EntityInventoryTypes.java
@@ -4,8 +4,6 @@ import org.cyclops.integratedtunnels.IntegratedTunnels;
 import org.cyclops.integratedtunnels.api.world.EntityInventoryTypeBase;
 import org.cyclops.integratedtunnels.api.world.IEntityInventoryTypeRegistry;
 
-import net.minecraft.util.Direction;
-
 /**
  * Collection of {@link EntityInventoryTypeBase}s.
  * @author met4000
@@ -21,11 +19,9 @@ public class EntityInventoryTypes {
     
     // the armor inventory of an entity
     public static final EntityInventoryTypeBase ARMOR = new EntityInventoryType("armor");
-    public static final Direction ARMOR_SIDE = Direction.NORTH;
     
     // the main inventory of an entity
     public static final EntityInventoryTypeBase INVENTORY = new EntityInventoryType("inventory");
-    public static final Direction INVENTORY_SIDE = Direction.UP;
     
     // TODO: ENDERINVENTORY, for players ?
     

--- a/src/main/java/org/cyclops/integratedtunnels/core/world/EntityInventoryTypes.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/world/EntityInventoryTypes.java
@@ -21,11 +21,11 @@ public class EntityInventoryTypes {
     
     // the armor inventory of an entity
     public static final EntityInventoryTypeBase ARMOR = new EntityInventoryType("armor");
-    public static final Direction ARMOR_SIDE = Direction.UP; // TODO verify
+    public static final Direction ARMOR_SIDE = Direction.NORTH;
     
     // the main inventory of an entity
     public static final EntityInventoryTypeBase INVENTORY = new EntityInventoryType("inventory");
-    public static final Direction INVENTORY_SIDE = Direction.NORTH; // TODO verify
+    public static final Direction INVENTORY_SIDE = Direction.UP;
     
     // TODO: ENDERINVENTORY, for players ?
     

--- a/src/main/java/org/cyclops/integratedtunnels/core/world/EntityInventoryTypes.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/world/EntityInventoryTypes.java
@@ -1,0 +1,34 @@
+package org.cyclops.integratedtunnels.core.world;
+
+import org.cyclops.integratedtunnels.IntegratedTunnels;
+import org.cyclops.integratedtunnels.api.world.EntityInventoryTypeBase;
+import org.cyclops.integratedtunnels.api.world.IEntityInventoryTypeRegistry;
+
+import net.minecraft.util.Direction;
+
+/**
+ * Collection of {@link EntityInventoryTypeBase}s.
+ * @author met4000
+ */
+public class EntityInventoryTypes {
+    
+    // TYPES NOT ADDED TO REGISTRY HERE: delegated to {@link EntityIItemTargetProxyBase}
+    public static final IEntityInventoryTypeRegistry REGISTRY = IntegratedTunnels._instance.getRegistryManager()
+            .getRegistry(IEntityInventoryTypeRegistry.class);
+    
+    // default inventory type (accesses either armor or inventory based on the side)
+    public static final EntityInventoryTypeBase SIDED = new EntityInventoryType("sided");
+    
+    // the armor inventory of an entity
+    public static final EntityInventoryTypeBase ARMOR = new EntityInventoryType("armor");
+    public static final Direction ARMOR_SIDE = Direction.UP; // TODO verify
+    
+    // the main inventory of an entity
+    public static final EntityInventoryTypeBase INVENTORY = new EntityInventoryType("inventory");
+    public static final Direction INVENTORY_SIDE = Direction.NORTH; // TODO verify
+    
+    // TODO: ENDERINVENTORY, for players ?
+    
+    public static void load() {}
+    
+}

--- a/src/main/java/org/cyclops/integratedtunnels/part/aspect/IItemTarget.java
+++ b/src/main/java/org/cyclops/integratedtunnels/part/aspect/IItemTarget.java
@@ -3,7 +3,6 @@ package org.cyclops.integratedtunnels.part.aspect;
 import net.minecraft.entity.Entity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.Direction;
 
 import org.cyclops.commoncapabilities.api.ingredient.storage.IIngredientComponentStorage;
 import org.cyclops.integrateddynamics.api.network.INetwork;

--- a/src/main/java/org/cyclops/integratedtunnels/part/aspect/IItemTarget.java
+++ b/src/main/java/org/cyclops/integratedtunnels/part/aspect/IItemTarget.java
@@ -3,14 +3,18 @@ package org.cyclops.integratedtunnels.part.aspect;
 import net.minecraft.entity.Entity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.Direction;
+
 import org.cyclops.commoncapabilities.api.ingredient.storage.IIngredientComponentStorage;
 import org.cyclops.integrateddynamics.api.network.INetwork;
 import org.cyclops.integrateddynamics.api.part.PartPos;
 import org.cyclops.integrateddynamics.api.part.PartTarget;
 import org.cyclops.integrateddynamics.api.part.aspect.property.IAspectProperties;
 import org.cyclops.integratedtunnels.api.network.IItemNetwork;
+import org.cyclops.integratedtunnels.api.world.IEntityIItemTargetProxy;
 import org.cyclops.integratedtunnels.core.part.PartStateRoundRobin;
 import org.cyclops.integratedtunnels.core.predicate.IngredientPredicate;
+import org.cyclops.integratedtunnels.core.world.EntityIItemTargetProxies;
 
 import javax.annotation.Nullable;
 
@@ -51,7 +55,14 @@ public interface IItemTarget extends IChanneledTarget<IItemNetwork, ItemStack> {
         PartPos target = partTarget.getTarget();
         INetwork network = IChanneledTarget.getNetworkChecked(center);
         PartStateRoundRobin<?> partState = IChanneledTarget.getPartState(center);
-        return new ItemTargetCapabilityProvider(transfer, network, entity, target.getSide(),
+        
+        IEntityIItemTargetProxy proxy = EntityIItemTargetProxies.REGISTRY.getHandler(transfer, network, entity,
+                target.getSide(), slot, itemStackMatcher, partTarget, properties, partState);
+        if (proxy == null) {
+            return null; // is there a special null IItemTarget?
+        }
+        
+        return proxy.evaluate(transfer, network, entity, target.getSide(),
                 slot, itemStackMatcher, partTarget, properties, partState);
     }
 

--- a/src/main/java/org/cyclops/integratedtunnels/part/aspect/TunnelAspectWriteBuilders.java
+++ b/src/main/java/org/cyclops/integratedtunnels/part/aspect/TunnelAspectWriteBuilders.java
@@ -67,6 +67,8 @@ import org.cyclops.integratedtunnels.core.part.IPartTypeInterfacePositionedAddon
 import org.cyclops.integratedtunnels.core.part.PartStatePositionedAddon;
 import org.cyclops.integratedtunnels.core.part.PartTypeInterfacePositionedAddonFiltering;
 import org.cyclops.integratedtunnels.core.predicate.IngredientPredicate;
+import org.cyclops.integratedtunnels.core.world.EntityInventoryType;
+import org.cyclops.integratedtunnels.core.world.EntityInventoryTypes;
 import org.cyclops.integratedtunnels.part.PartStatePlayerSimulator;
 
 import javax.annotation.Nullable;
@@ -1246,6 +1248,8 @@ public class TunnelAspectWriteBuilders {
                 input -> input.getRawValue() >= -180D && input.getRawValue() <= 180F;
         public static final Predicate<ValueTypeDouble.ValueDouble> VALIDATOR_DOUBLE_OFFSET =
                 input -> input.getRawValue() >= 0.01D && input.getRawValue() <= 1.01F;
+        public static final Predicate<ValueTypeString.ValueString> VALIDATOR_STRING_ENTITYINVENTORY =
+                input -> EntityInventoryTypes.REGISTRY.getTypes().contains(EntityInventoryType.fromString(input.getRawValue())); // is there a better way to do this?
 
         public static final IAspectPropertyTypeInstance<ValueTypeBoolean, ValueTypeBoolean.ValueBoolean> PROP_BLOCK_UPDATE =
                 new AspectPropertyTypeInstance<>(ValueTypes.BOOLEAN, "aspect.aspecttypes.integratedtunnels.boolean.world.blockupdate");
@@ -1280,6 +1284,8 @@ public class TunnelAspectWriteBuilders {
                 new AspectPropertyTypeInstance<>(ValueTypes.DOUBLE, "aspect.aspecttypes.integratedtunnels.double.world.pitch", VALIDATOR_DOUBLE_ANGLE);
         public static final IAspectPropertyTypeInstance<ValueTypeInteger, ValueTypeInteger.ValueInteger> PROPERTY_ENTITYINDEX =
                 new AspectPropertyTypeInstance<>(ValueTypes.INTEGER, "aspect.aspecttypes.integratedtunnels.integer.entityindex");
+        public static final IAspectPropertyTypeInstance<ValueTypeString, ValueTypeString.ValueString> PROPERTY_ENTITYINVENTORY =
+                new AspectPropertyTypeInstance<>(ValueTypes.STRING, "aspect.aspecttypes.integratedtunnels.string.entityinventory", VALIDATOR_STRING_ENTITYINVENTORY);
 
         public static final class Energy {
 
@@ -1456,6 +1462,8 @@ public class TunnelAspectWriteBuilders {
             static {
                 PROPERTIES_RATESLOT.setValue(World.PROPERTY_ENTITYINDEX, ValueTypeInteger.ValueInteger.of(0));
                 PROPERTIES_RATESLOT.removeValue(PROP_PASSIVE_IO);
+                PROPERTIES_RATESLOT.setValue(World.PROPERTY_ENTITYINVENTORY,
+                        ValueTypeString.ValueString.of(EntityInventoryTypes.SIDED.getName()));
 
                 PROPERTIES_SLOT.setValue(World.PROPERTY_ENTITYINDEX, ValueTypeInteger.ValueInteger.of(0));
                 PROPERTIES_SLOT.removeValue(PROP_PASSIVE_IO);

--- a/src/main/java/org/cyclops/integratedtunnels/part/aspect/TunnelAspectWriteBuilders.java
+++ b/src/main/java/org/cyclops/integratedtunnels/part/aspect/TunnelAspectWriteBuilders.java
@@ -1285,7 +1285,7 @@ public class TunnelAspectWriteBuilders {
         public static final IAspectPropertyTypeInstance<ValueTypeInteger, ValueTypeInteger.ValueInteger> PROPERTY_ENTITYINDEX =
                 new AspectPropertyTypeInstance<>(ValueTypes.INTEGER, "aspect.aspecttypes.integratedtunnels.integer.entityindex");
         public static final IAspectPropertyTypeInstance<ValueTypeString, ValueTypeString.ValueString> PROPERTY_ENTITYINVENTORY =
-                new AspectPropertyTypeInstance<>(ValueTypes.STRING, "aspect.aspecttypes.integratedtunnels.string.entityinventory", VALIDATOR_STRING_ENTITYINVENTORY);
+                new AspectPropertyTypeInstance<>(ValueTypes.STRING, "aspect.aspecttypes.integratedtunnels.string.world.entityinventory", VALIDATOR_STRING_ENTITYINVENTORY);
 
         public static final class Energy {
 
@@ -1454,6 +1454,7 @@ public class TunnelAspectWriteBuilders {
 
                 PROPERTIES_ENTITYITEM_PLACELIST.setValue(PROP_BLACKLIST, ValueTypeBoolean.ValueBoolean.of(false));
             }
+            
             public static final IAspectProperties PROPERTIES_RATESLOT = TunnelAspectWriteBuilders.Item.PROPERTIES_RATESLOT.clone();
             public static final IAspectProperties PROPERTIES_SLOT = TunnelAspectWriteBuilders.Item.PROPERTIES_SLOT.clone();
             public static final IAspectProperties PROPERTIES_RATESLOTCHECKS = TunnelAspectWriteBuilders.Item.PROPERTIES_RATESLOTCHECKS.clone();
@@ -1461,23 +1462,31 @@ public class TunnelAspectWriteBuilders {
             public static final IAspectProperties PROPERTIES_NBT = TunnelAspectWriteBuilders.Item.PROPERTIES_NBT.clone();
             static {
                 PROPERTIES_RATESLOT.setValue(World.PROPERTY_ENTITYINDEX, ValueTypeInteger.ValueInteger.of(0));
-                PROPERTIES_RATESLOT.removeValue(PROP_PASSIVE_IO);
                 PROPERTIES_RATESLOT.setValue(World.PROPERTY_ENTITYINVENTORY,
                         ValueTypeString.ValueString.of(EntityInventoryTypes.SIDED.getName()));
+                PROPERTIES_RATESLOT.removeValue(PROP_PASSIVE_IO);
 
                 PROPERTIES_SLOT.setValue(World.PROPERTY_ENTITYINDEX, ValueTypeInteger.ValueInteger.of(0));
+                PROPERTIES_SLOT.setValue(World.PROPERTY_ENTITYINVENTORY,
+                        ValueTypeString.ValueString.of(EntityInventoryTypes.SIDED.getName()));
                 PROPERTIES_SLOT.removeValue(PROP_PASSIVE_IO);
 
                 PROPERTIES_RATESLOTCHECKS.setValue(World.PROPERTY_ENTITYINDEX, ValueTypeInteger.ValueInteger.of(0));
+                PROPERTIES_RATESLOTCHECKS.setValue(World.PROPERTY_ENTITYINVENTORY,
+                        ValueTypeString.ValueString.of(EntityInventoryTypes.SIDED.getName()));
                 PROPERTIES_RATESLOTCHECKS.setValue(PROP_BLACKLIST, ValueTypeBoolean.ValueBoolean.of(false));
                 PROPERTIES_RATESLOTCHECKS.setValue(PROP_EMPTYISANY, ValueTypeBoolean.ValueBoolean.of(false));
                 PROPERTIES_RATESLOTCHECKS.removeValue(PROP_PASSIVE_IO);
 
                 PROPERTIES_RATESLOTCHECKSCRAFT.setValue(World.PROPERTY_ENTITYINDEX, ValueTypeInteger.ValueInteger.of(0));
+                PROPERTIES_RATESLOTCHECKSCRAFT.setValue(World.PROPERTY_ENTITYINVENTORY,
+                        ValueTypeString.ValueString.of(EntityInventoryTypes.SIDED.getName()));
                 PROPERTIES_RATESLOTCHECKSCRAFT.setValue(PROP_BLACKLIST, ValueTypeBoolean.ValueBoolean.of(false));
                 PROPERTIES_RATESLOTCHECKSCRAFT.removeValue(PROP_PASSIVE_IO);
 
                 PROPERTIES_NBT.setValue(World.PROPERTY_ENTITYINDEX, ValueTypeInteger.ValueInteger.of(0));
+                PROPERTIES_NBT.setValue(World.PROPERTY_ENTITYINVENTORY,
+                        ValueTypeString.ValueString.of(EntityInventoryTypes.SIDED.getName()));
                 PROPERTIES_NBT.removeValue(PROP_PASSIVE_IO);
             }
             public static final IAspectProperties PROPERTIES_RATESLOTCHECKSLIST = PROPERTIES_RATESLOTCHECKS.clone();

--- a/src/main/resources/assets/integratedtunnels/lang/en_us.json
+++ b/src/main/resources/assets/integratedtunnels/lang/en_us.json
@@ -149,7 +149,7 @@
   "aspect.aspecttypes.integratedtunnels.integer.entityindex": "Entity Index",
   "aspect.aspecttypes.integratedtunnels.integer.entityindex.info": "The n-th entity that will be picked. -1 will always pick a random entity.",
   "aspect.aspecttypes.integratedtunnels.string.world.entityinventory": "Entity Inventory",
-  "aspect.aspecttypes.integratedtunnels.string.world.entityinventory.info": "The inventory to use of the entity.",
+  "aspect.aspecttypes.integratedtunnels.string.world.entityinventory.info": "The inventory to use of the entity e.g. sided, inventory, or armor.",
   "aspect.aspecttypes.integratedtunnels.boolean.player.continuousclick": "Continuous Click",
   "aspect.aspecttypes.integratedtunnels.boolean.player.continuousclick.info": "If a continuous click must be simulated, otherwise each click takes one tick.",
   "aspect.aspecttypes.integratedtunnels.boolean.blacklist": "Blacklist",

--- a/src/main/resources/assets/integratedtunnels/lang/en_us.json
+++ b/src/main/resources/assets/integratedtunnels/lang/en_us.json
@@ -148,6 +148,8 @@
   "aspect.aspecttypes.integratedtunnels.boolean.player.rightclick": "Right Click",
   "aspect.aspecttypes.integratedtunnels.integer.entityindex": "Entity Index",
   "aspect.aspecttypes.integratedtunnels.integer.entityindex.info": "The n-th entity that will be picked. -1 will always pick a random entity.",
+  "aspect.aspecttypes.integratedtunnels.string.world.entityinventory": "Entity Inventory",
+  "aspect.aspecttypes.integratedtunnels.string.world.entityinventory.info": "The inventory to use of the entity.",
   "aspect.aspecttypes.integratedtunnels.boolean.player.continuousclick": "Continuous Click",
   "aspect.aspecttypes.integratedtunnels.boolean.player.continuousclick.info": "If a continuous click must be simulated, otherwise each click takes one tick.",
   "aspect.aspecttypes.integratedtunnels.boolean.blacklist": "Blacklist",


### PR DESCRIPTION
Adds an "Entity Inventory" option to aspects on world item tunnels that interact with entity inventories, to specify if the default "sided" method should be used to select the inventory type, or if a specific inventory type should be used. Currently implemented options are "sided" (current behaviour), "armor", and "inventory" (could be renamed to "main inventory" or "main"). Possible additional options include "ender"/"ender inventory", to allow the world item tunnels to access the ender chests of players.

From a technical standpoint; adds a registry that is used to determine the `IItemTarget` used by the world item tunnel based on various properties. The current proxies in the registry work solely based on the `World.PROPERTY_ENTITYINVENTORY` `IAspectProperty`. The reason for using a registry over other more direct methods is for InTu-Compat to be able to add extra proxies to the registry; see issue [#2](https://github.com/CyclopsMC/IntegratedTunnels-Compat/issues/2) on InTu-Compat.