### PR TITLE
Run performance tests in CI

### DIFF
--- a/.github/parse_benchmark_results.sh
+++ b/.github/parse_benchmark_results.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Parse benchmark results from game tests and convert to JSON format
+# This script reads the benchmark results file and converts it to JSON format
+# for use with benchmark-action/github-action-benchmark
+
+set -e
+
+BENCH_FILE="benchmark_results.json"
+RESULTS_FILE="runs/gameTestServer/logs/benchmark_results.txt"
+
+echo "Parsing benchmark results..."
+
+# Initialize the JSON array
+echo "[" > "$BENCH_FILE"
+
+# Default values if file doesn't exist
+if [ ! -f "$RESULTS_FILE" ]; then
+    echo "Benchmark results file not found at $RESULTS_FILE"
+    exit 1;
+fi
+
+FIRST=true
+while IFS= read -r line; do
+    # Skip empty lines
+    if [ -z "$line" ]; then
+        continue
+    fi
+
+    # Parse the line: preset=<preset> size=<size> avgNetworkTickTime=<time> avgServerTickTime=<time>
+    # Using sed instead of grep -oP for macOS compatibility
+    preset=$(echo "$line" | sed -n 's/.*preset=\([^ ]*\).*/\1/p')
+    size=$(echo "$line" | sed -n 's/.*size=\([0-9]*\).*/\1/p')
+    networkTickTime=$(echo "$line" | sed -n 's/.*avgNetworkTickTime=\([0-9.]*\).*/\1/p')
+    serverTickTime=$(echo "$line" | sed -n 's/.*avgServerTickTime=\([0-9.]*\).*/\1/p')
+
+    if [ -n "$preset" ] && [ -n "$size" ] && [ -n "$networkTickTime" ]; then
+        # Output network tick time metric
+        if [ "$FIRST" = true ]; then
+            FIRST=false
+        else
+            echo "," >> "$BENCH_FILE"
+        fi
+
+        cat >> "$BENCH_FILE" << EOF
+  {
+    "name": "NETWORK LOAD: ${preset}_size_${size}",
+    "unit": "tick time (ms)",
+    "value": $networkTickTime
+  }
+EOF
+    fi
+
+    # Output server tick time metric if available
+    if [ -n "$serverTickTime" ]; then
+        echo "," >> "$BENCH_FILE"
+        cat >> "$BENCH_FILE" << EOF
+  {
+    "name": "SERVER LOAD: ${preset}_size_${size}",
+    "unit": "tick time (ms)",
+    "value": $serverTickTime
+  }
+EOF
+    fi
+done < "$RESULTS_FILE"
+
+# Close the JSON array
+echo "" >> "$BENCH_FILE"
+echo "]" >> "$BENCH_FILE"
+
+# Display the results
+echo "✓ Benchmark results parsed successfully:"
+echo ""
+cat "$BENCH_FILE"
+

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,64 @@
+name: "Performance"
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    name: Benchmark
+    if: github.event.repository.fork != true && (startsWith(github.ref, 'refs/heads/master') || startsWith(github.ref, 'refs/heads/feature'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: 'Setup Java'
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'microsoft'
+          java-version: 21
+      - name: 'Setup Gradle'
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
+          cache-read-only: false
+      - name: 'Build'
+        run: ./gradlew build -x test --no-daemon
+        env:
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 'Run performance benchmarks'
+        run: ./gradlew runGameTestServer
+        env:
+          PERFORMANCE_BENCHMARK_ENABLED: 'true'
+        continue-on-error: true
+      - name: 'Parse benchmark results'
+        run: bash .github/parse_benchmark_results.sh
+      - name: Determine benchmarks total results target directory name
+        run: echo "BENCHMARK_DATA_DIR_PATH=CyclopsMC/IntegratedTunnels/${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}/benchmarks" >> $GITHUB_ENV
+      - name: 'Store benchmark result'
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Integrated Tunnels Network Benchmark
+          tool: customSmallerIsBetter
+          output-file-path: benchmark_results.json
+          github-token: ${{ secrets.PAT }}
+          auto-push: true
+          alert-threshold: '250%'
+          comment-always: true
+          comment-on-alert: true
+          alert-comment-cc-users: '@rubensworks'
+          summary-always: true
+          gh-repository: github.com/CyclopsMC/cyclops-performance-results
+          gh-pages-branch: master
+          benchmark-data-dir-path: ${{ env.BENCHMARK_DATA_DIR_PATH }}
+      - name: Prepare comment on commit with link to performance results
+        run: echo -e "Performance benchmarks succeeded! 🚀\n\n\[[Results](https://CyclopsMC.github.io/cyclops-performance-results/CyclopsMC/IntegratedTunnels/${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}/benchmarks/)\]" > ./commit-comment-body.txt
+      - name: Comment on commit with link to performance results
+        uses: peter-evans/commit-comment@v4
+        with:
+          body-path: ./commit-comment-body.txt
+

--- a/PERFORMANCE_BENCHMARKING.md
+++ b/PERFORMANCE_BENCHMARKING.md
@@ -1,0 +1,209 @@
+# Performance Benchmarking Setup
+
+This document describes the performance benchmarking infrastructure for Integrated Tunnels,
+which measures the continuous performance of tunnel operations on Integrated Dynamics networks.
+Performance results are tracked in https://github.com/CyclopsMC/cyclops-performance-results
+
+This setup mirrors the one of [Integrated Dynamics](https://github.com/CyclopsMC/IntegratedDynamics/blob/master-1.21-lts/PERFORMANCE_BENCHMARKING.md),
+and reuses its measurement infrastructure.
+Where Integrated Dynamics measures the cost of the network graph and variable evaluation,
+these benchmarks measure the cost of what Integrated Tunnels adds on top of it:
+ingredient observation, ingredient transfer, index querying, and world interaction.
+
+## Overview
+
+The performance benchmarking system consists of three main components:
+
+1. **GitHub Workflow** (`.github/workflows/performance.yml`)
+   - Executes on the same triggers as CI (push and pull_request)
+   - Runs game tests to measure network performance
+   - Uses `benchmark-action/github-action-benchmark` to track performance evolution
+
+2. **Game Tests** (`src/main/java/org/cyclops/integratedtunnels/gametest/GameTestsPerformance.java`)
+   - Generates networks with different presets for benchmarking
+   - Measures performance metrics for each preset
+   - Writes results to `runs/gameTestServer/logs/benchmark_results.txt`
+
+3. **Network Generation Command** (`src/main/java/org/cyclops/integratedtunnels/command/CommandGenerateTunnels.java`)
+   - Provides `/integratedtunnels generatetunnels` command for manual testing
+   - Supports all presets that the benchmarks use, plus `clear`
+   - Can be used in both single-player and multiplayer environments
+
+## Grid Layout
+
+All presets are built on top of the same grid layout, so that their results are comparable:
+
+- Even Y levels are fully filled with logic cables.
+- Odd Y levels alternate between logic cables and free **cells**.
+
+Every cell is a free position that is fully surrounded by cables of a single network.
+This means a cell can hold a container that is observed by an interface on the cable below it,
+and that is simultaneously targeted by importers or exporters on the cables next to it.
+A grid of size 9 (the size used in the benchmarks, which is the largest that fits in the game test template)
+contains 569 cables and 160 cells.
+
+## Network Presets
+
+### Storage observation
+
+These presets isolate the cost of the ingredient observers that watch every container
+that an interface exposes to the network.
+No ingredients are moved: this is the idle cost of simply having storage attached to a network.
+
+| Preset | Description |
+| --- | --- |
+| `interfaces_item_idle` | Every cell holds a chest with 9 distinct item types, exposed by an item interface |
+| `interfaces_fluid_idle` | Every cell holds a filled drying basin, exposed by a fluid interface |
+| `interfaces_energy_idle` | Every cell holds a filled energy battery, exposed by an energy interface |
+| `interfaces_item_idle_deep` | Only 16 cells, but with completely filled chests, which shifts the cost from the number of observed positions to the number of observed slots |
+
+### Active transfer
+
+These presets continuously move ingredients around.
+Every other cell is network storage, and the remaining cells run an exporter that pushes
+ingredients out of the network into the cell, plus an importer that pulls them back in.
+
+| Preset | Description |
+| --- | --- |
+| `items_transfer` | Items are continuously exported and imported again |
+| `fluids_transfer` | Fluids are continuously exported and imported again |
+| `energy_transfer` | Energy is continuously exported and imported again |
+| `items_transfer_predicate` | As `items_transfer`, but driven by predicate aspects, which additionally measures the cost of evaluating a predicate per candidate ingredient |
+| `items_filtering_interfaces` | As `items_transfer`, but with filtering item interfaces as network storage |
+
+### Index scaling
+
+| Preset | Description |
+| --- | --- |
+| `items_index_query` | Three quarters of the cells hold chests with distinct item types, resulting in a large network index. The remaining cells continuously query one specific itemstack out of that index and import it back |
+
+### Topology churn
+
+| Preset | Description |
+| --- | --- |
+| `interfaces_item_append` | Starts from a cable-only grid, and adds one item interface with a filled chest per tick after warming up, measuring the cost of registering positions in the ingredient networks |
+| `interfaces_item_remove` | Starts from a fully populated grid, and removes one item interface with its chest per tick after warming up, measuring the cost of unregistering positions and splitting networks |
+
+### World-interacting parts
+
+| Preset | Description |
+| --- | --- |
+| `world_block_churn` | Block exporters continuously place blocks into the cells, while block importers break them again |
+| `world_entityitem_churn` | Entity item exporters continuously drop items into the cells, while entity item importers pick them up again |
+| `player_simulator` | Player simulators continuously simulate right-clicks |
+
+## Performance Metrics
+
+The benchmarking system measures two key metrics:
+
+- **Average Network Tick Time (ms)**: The average time the Integrated Dynamics network subsystem takes
+  to process one game tick. This is the sum of the time spent in the network's parts
+  (which for these benchmarks are mostly Integrated Tunnels parts)
+  and the time spent in the ingredient observers of the item, fluid and energy channels.
+- **Average Server Tick Time (ms)**: The average time the entire Minecraft server takes per game tick.
+  This measures the overall server performance impact, including both the network and all other server operations.
+- **Network Size**: The edge length of the generated grid
+
+These metrics are tracked separately in the benchmark results to distinguish between network-specific
+performance and overall server performance impact.
+
+## Game Test Execution
+
+The game tests are automatically executed as part of the GitHub workflow:
+
+```bash
+PERFORMANCE_BENCHMARK_ENABLED=true ./gradlew runGameTestServer
+```
+
+This command:
+1. Starts a game test server
+2. Runs `GameTestsPerformance` game tests
+3. Generates networks with different presets
+4. Measures performance metrics
+5. Writes results to `runs/gameTestServer/logs/benchmark_results.txt`
+
+When `PERFORMANCE_BENCHMARK_ENABLED` is not set, all of these game tests succeed immediately without
+generating or measuring anything, so that regular `./gradlew runGameTestServer` runs are not slowed down.
+
+## Result Format
+
+Results are written in the following format:
+```
+preset=interfaces_item_idle size=9 avgNetworkTickTime=6.25 avgServerTickTime=3.50
+preset=items_transfer size=9 avgNetworkTickTime=7.50 avgServerTickTime=4.20
+```
+
+Results are then converted to JSON format for the benchmark action.
+Each preset generates two metrics - one for network tick time and one for server tick time:
+```json
+[
+  {
+    "name": "NETWORK LOAD: interfaces_item_idle_size_9",
+    "unit": "tick time (ms)",
+    "value": 6.25
+  },
+  {
+    "name": "SERVER LOAD: interfaces_item_idle_size_9",
+    "unit": "tick time (ms)",
+    "value": 3.50
+  }
+]
+```
+
+## Benchmark Tracking
+
+The `benchmark-action/github-action-benchmark` GitHub action automatically:
+- Stores benchmark results in the `CyclopsMC/IntegratedTunnels/<branch>/benchmarks` directory
+  of the `CyclopsMC/cyclops-performance-results` repository
+  (note the extra repository name segment compared to Integrated Dynamics,
+  which is needed because both mods share branch names)
+- Generates historical performance charts
+- Alerts when performance degrades beyond 250% of baseline
+- Creates comments on commits and PRs when alerts are triggered
+
+## Manual Testing
+
+To manually test tunnel performance in a Minecraft world:
+
+1. **Generate a network of item interfaces**:
+   ```
+   /integratedtunnels generatetunnels iteminterfaces 9
+   ```
+
+2. **Generate a network that continuously transfers items**:
+   ```
+   /integratedtunnels generatetunnels itemtransfer 9
+   ```
+
+3. **Measure network performance** (provided by Integrated Dynamics):
+   ```
+   /integrateddynamics networkdiagnostics measure 10
+   ```
+
+4. **Clear generated networks**:
+   ```
+   /integratedtunnels generatetunnels clear 50
+   ```
+
+Note that the generation is `O(size^3)`, and that every cell adds a container that is observed every tick,
+so sizes much larger than 9 will quickly become very heavy.
+
+## Integration with CI/CD
+
+The performance workflow runs on:
+- Every push to any `master*` or `feature*` branch
+- Every pull request
+
+Performance degradation is tracked across commits and branches, helping to identify performance regressions
+early in the development cycle.
+
+## Adding New Benchmarks
+
+To add new network presets or benchmarks:
+
+1. Add a new preset enum value in `CommandGenerateTunnels.TunnelsPreset`
+2. Add a corresponding generation method in `CommandGenerateTunnels.TunnelsGenerationHelper`,
+   and dispatch to it from `TunnelsGenerationHelper.generate`
+3. Add a new `@GameTest` method in `GameTestsPerformance`, with a unique `batch` name,
+   so that the benchmark runs in isolation from the other benchmarks
+4. The workflow will automatically execute and track the new benchmark

--- a/PERFORMANCE_BENCHMARKING.md
+++ b/PERFORMANCE_BENCHMARKING.md
@@ -55,7 +55,7 @@ No ingredients are moved: this is the idle cost of simply having storage attache
 | `interfaces_item_idle` | Every cell holds a chest with 9 distinct item types, exposed by an item interface |
 | `interfaces_fluid_idle` | Every cell holds a filled drying basin, exposed by a fluid interface |
 | `interfaces_energy_idle` | Every cell holds a filled energy battery, exposed by an energy interface |
-| `interfaces_item_idle_deep` | Only 16 cells, but with completely filled chests, which shifts the cost from the number of observed positions to the number of observed slots |
+| `interfaces_item_idle_deep` | Only 64 cells, but with completely filled chests, which shifts the cost from the number of observed positions to the number of observed slots: 1728 observed slots across 64 positions, against 1440 slots across 160 positions for `interfaces_item_idle` |
 
 ### Active transfer
 
@@ -68,7 +68,7 @@ ingredients out of the network into the cell, plus an importer that pulls them b
 | `items_transfer` | Items are continuously exported and imported again |
 | `fluids_transfer` | Fluids are continuously exported and imported again |
 | `energy_transfer` | Energy is continuously exported and imported again |
-| `items_transfer_predicate` | As `items_transfer`, but driven by predicate aspects, which additionally measures the cost of evaluating a predicate per candidate ingredient |
+| `items_transfer_predicate` | As `items_transfer`, but driven by predicate aspects, which additionally measures the cost of evaluating a predicate per candidate ingredient. The predicate matches on the raw item, because itemstack equality also compares stack sizes |
 | `items_filtering_interfaces` | As `items_transfer`, but with filtering item interfaces as network storage |
 
 ### Index scaling

--- a/src/main/java/org/cyclops/integratedtunnels/IntegratedTunnels.java
+++ b/src/main/java/org/cyclops/integratedtunnels/IntegratedTunnels.java
@@ -1,6 +1,10 @@
 package org.cyclops.integratedtunnels;
 
 import com.google.common.collect.Lists;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import net.minecraft.commands.CommandBuildContext;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.api.distmarker.Dist;
@@ -24,6 +28,7 @@ import org.cyclops.integratedtunnels.api.world.IBlockBreakHandlerRegistry;
 import org.cyclops.integratedtunnels.api.world.IBlockPlaceHandlerRegistry;
 import org.cyclops.integratedtunnels.capability.ingredient.TunnelIngredientComponentCapabilities;
 import org.cyclops.integratedtunnels.capability.network.TunnelNetworkCapabilityConstructors;
+import org.cyclops.integratedtunnels.command.CommandGenerateTunnels;
 import org.cyclops.integratedtunnels.core.ItemStoragePlayerWrapper;
 import org.cyclops.integratedtunnels.core.part.ContainerInterfaceSettingsConfig;
 import org.cyclops.integratedtunnels.core.world.BlockBreakHandlerRegistry;
@@ -70,6 +75,15 @@ public class IntegratedTunnels extends ModBaseVersionable<IntegratedTunnels> {
         PartTypes.load();
         BlockBreakHandlers.load();
         BlockPlaceHandlers.load();
+    }
+
+    @Override
+    protected LiteralArgumentBuilder<CommandSourceStack> constructBaseCommand(Commands.CommandSelection selection, CommandBuildContext context) {
+        LiteralArgumentBuilder<CommandSourceStack> root = super.constructBaseCommand(selection, context);
+
+        root.then(CommandGenerateTunnels.make());
+
+        return root;
     }
 
     @Override

--- a/src/main/java/org/cyclops/integratedtunnels/command/CommandGenerateTunnels.java
+++ b/src/main/java/org/cyclops/integratedtunnels/command/CommandGenerateTunnels.java
@@ -13,6 +13,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.Container;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
@@ -101,7 +102,7 @@ public class CommandGenerateTunnels implements Command<CommandSourceStack> {
         FLUIDINTERFACES,
         /** Energy interfaces observing filled energy batteries. */
         ENERGYINTERFACES,
-        /** A few item interfaces observing completely filled chests. */
+        /** Fewer item interfaces, but observing completely filled chests. */
         ITEMINTERFACESDEEP,
         /** Item interfaces with item exporters and importers continuously moving items around. */
         ITEMTRANSFER,
@@ -213,8 +214,11 @@ public class CommandGenerateTunnels implements Command<CommandSourceStack> {
 
         /**
          * The number of cells that the "deep" preset uses.
+         * This is chosen so that the preset observes fewer positions but more total slots
+         * than {@link #generateItemInterfaces}, which is what makes it "deep":
+         * 64 completely filled chests hold 1728 slots, against 160 chests holding 1440 slots.
          */
-        public static final int DEEP_CELLS = 16;
+        public static final int DEEP_CELLS = 64;
 
         /**
          * The amount of fluid that is inserted into each generated fluid container.
@@ -383,9 +387,12 @@ public class CommandGenerateTunnels implements Command<CommandSourceStack> {
          * Create a variable holding a predicate that matches the given item.
          */
         public static ItemStack createItemPredicate(ServerLevel level, Item item) {
+            // Match on the raw item only. Itemstack equality includes the stack size
+            // (ItemMatch.EXACT contains ItemMatch.STACKSIZE), so a general equality operator
+            // would never match the full stacks that the generated containers are filled with.
             return GameTestHelpersIntegratedDynamics.createVariableForValue(level, ValueTypes.OPERATOR,
                     ValueTypeOperator.ValueOperator.of(new CurriedOperator(
-                            Operators.RELATIONAL_EQUALS,
+                            Operators.OBJECT_ITEMSTACK_ISITEMEQUALNODATA,
                             new Variable<>(ValueObjectTypeItemStack.ValueItemStack.of(new ItemStack(item)))
                     )));
         }
@@ -769,6 +776,12 @@ public class CommandGenerateTunnels implements Command<CommandSourceStack> {
          * @param cell The cell to remove.
          */
         public static void removeCell(ServerLevel level, BlockPos cell) {
+            // Empty the container before removing it. Even without block drops, a container block
+            // spills its contents as item entities when it is removed, and ticking those entities
+            // would dominate the measurement instead of the network shrinking itself.
+            if (level.getBlockEntity(cell) instanceof Container container) {
+                container.clearContent();
+            }
             level.destroyBlock(cell, false);
             level.destroyBlock(cell.below(), false);
         }

--- a/src/main/java/org/cyclops/integratedtunnels/command/CommandGenerateTunnels.java
+++ b/src/main/java/org/cyclops/integratedtunnels/command/CommandGenerateTunnels.java
@@ -1,0 +1,871 @@
+package org.cyclops.integratedtunnels.command;
+
+import com.google.common.collect.Lists;
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import net.minecraft.ChatFormatting;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.entity.ChestBlockEntity;
+import net.minecraft.world.level.material.Fluids;
+import net.neoforged.neoforge.fluids.FluidStack;
+import org.cyclops.cyclopscore.command.argument.ArgumentTypeEnum;
+import org.cyclops.integrateddynamics.RegistryEntries;
+import org.cyclops.integrateddynamics.api.part.IPartType;
+import org.cyclops.integrateddynamics.api.part.PartPos;
+import org.cyclops.integrateddynamics.api.part.aspect.IAspectWrite;
+import org.cyclops.integrateddynamics.block.BlockCable;
+import org.cyclops.integrateddynamics.blockentity.BlockEntityDryingBasin;
+import org.cyclops.integrateddynamics.blockentity.BlockEntityEnergyBattery;
+import org.cyclops.integrateddynamics.core.evaluate.operator.CurriedOperator;
+import org.cyclops.integrateddynamics.core.evaluate.operator.Operators;
+import org.cyclops.integrateddynamics.core.evaluate.variable.ValueObjectTypeItemStack;
+import org.cyclops.integrateddynamics.core.evaluate.variable.ValueTypeOperator;
+import org.cyclops.integrateddynamics.core.evaluate.variable.ValueTypes;
+import org.cyclops.integrateddynamics.core.evaluate.variable.Variable;
+import org.cyclops.integrateddynamics.core.helper.CableHelpers;
+import org.cyclops.integrateddynamics.core.helper.NetworkHelpers;
+import org.cyclops.integrateddynamics.core.helper.PartHelpers;
+import org.cyclops.integrateddynamics.gametest.GameTestHelpersIntegratedDynamics;
+import org.cyclops.integratedtunnels.part.PartTypes;
+import org.cyclops.integratedtunnels.part.aspect.TunnelAspects;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+/**
+ * Command for generating tunnel networks with different presets.
+ *
+ * These presets are used for performance benchmarking,
+ * both from within game tests, and for manual profiling inside a real world.
+ *
+ * @author rubensworks
+ */
+public class CommandGenerateTunnels implements Command<CommandSourceStack> {
+
+    public static LiteralArgumentBuilder<CommandSourceStack> make() {
+        LiteralArgumentBuilder<CommandSourceStack> builder = Commands.literal("generatetunnels")
+                .requires((commandSource) -> commandSource.hasPermission(2));
+
+        // Add the preset subcommand with optional size argument
+        builder.then(Commands.argument("preset", new ArgumentTypeEnum(TunnelsPreset.class))
+                .executes(new CommandGenerateTunnelsExecutor(true, false))
+                .then(Commands.argument("size", IntegerArgumentType.integer(1, 100))
+                        .executes(new CommandGenerateTunnelsExecutor(true, true))));
+
+        return builder;
+    }
+
+    @Override
+    public int run(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
+        context.getSource().sendFailure(Component.literal("Please specify one of the presets: " + joinPresets())
+                .withStyle(ChatFormatting.RED));
+        return 0;
+    }
+
+    /**
+     * @return All preset names, joined by a comma.
+     */
+    public static String joinPresets() {
+        StringBuilder sb = new StringBuilder();
+        for (TunnelsPreset preset : TunnelsPreset.values()) {
+            if (sb.length() > 0) {
+                sb.append(", ");
+            }
+            sb.append(preset.name().toLowerCase());
+        }
+        return sb.toString();
+    }
+
+    /**
+     * The available network presets.
+     */
+    public enum TunnelsPreset {
+        /** Only cables, no parts: the baseline that the append benchmark grows from. */
+        EMPTY,
+        /** Item interfaces observing filled chests. */
+        ITEMINTERFACES,
+        /** Fluid interfaces observing filled drying basins. */
+        FLUIDINTERFACES,
+        /** Energy interfaces observing filled energy batteries. */
+        ENERGYINTERFACES,
+        /** A few item interfaces observing completely filled chests. */
+        ITEMINTERFACESDEEP,
+        /** Item interfaces with item exporters and importers continuously moving items around. */
+        ITEMTRANSFER,
+        /** Fluid interfaces with fluid exporters and importers continuously moving fluids around. */
+        FLUIDTRANSFER,
+        /** Energy interfaces with energy exporters and importers continuously moving energy around. */
+        ENERGYTRANSFER,
+        /** As {@link #ITEMTRANSFER}, but driven by predicate aspects instead of boolean aspects. */
+        ITEMTRANSFERPREDICATE,
+        /** As {@link #ITEMTRANSFER}, but with filtering item interfaces as network storage. */
+        ITEMFILTERINGINTERFACES,
+        /** Many item interfaces holding distinct item types, queried by itemstack exporters. */
+        ITEMINDEXQUERY,
+        /** World block exporters and importers continuously placing and breaking blocks. */
+        WORLDBLOCKCHURN,
+        /** World entity item exporters and importers continuously dropping and picking up items. */
+        WORLDENTITYITEMCHURN,
+        /** Player simulators continuously simulating right-clicks. */
+        PLAYERSIMULATORS,
+        /** Remove everything that the other presets generate. */
+        CLEAR,
+    }
+
+    /**
+     * Executor for the generatetunnels command.
+     */
+    public static class CommandGenerateTunnelsExecutor implements Command<CommandSourceStack> {
+        private final boolean hasPreset;
+        private final boolean hasSize;
+
+        public CommandGenerateTunnelsExecutor(boolean hasPreset, boolean hasSize) {
+            this.hasPreset = hasPreset;
+            this.hasSize = hasSize;
+        }
+
+        @Override
+        public int run(CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
+            if (!hasPreset) {
+                context.getSource().sendFailure(Component.literal("Please specify one of the presets: " + joinPresets())
+                        .withStyle(ChatFormatting.RED));
+                return 0;
+            }
+
+            TunnelsPreset preset = ArgumentTypeEnum.getValue(context, "preset", TunnelsPreset.class);
+            ServerLevel level = context.getSource().getLevel();
+            BlockPos playerPos = BlockPos.containing(context.getSource().getPosition());
+            int size = hasSize ? IntegerArgumentType.getInteger(context, "size") : getDefaultSize(preset);
+
+            if (preset == TunnelsPreset.CLEAR) {
+                context.getSource().sendSuccess(
+                        () -> Component.literal("Clearing generated tunnel networks within radius: " + size)
+                                .withStyle(ChatFormatting.GREEN),
+                        true);
+                TunnelsGenerationHelper.clearGrid(level, playerPos, size);
+                return 1;
+            }
+
+            context.getSource().sendSuccess(
+                    () -> Component.literal("Generating tunnels preset: " + preset.name().toLowerCase()
+                                    + " (size: " + size + "x" + size + "x" + size + ")")
+                            .withStyle(ChatFormatting.GREEN),
+                    true);
+            TunnelsGenerationHelper.generate(preset, level, playerPos.above(2), size);
+
+            return 1;
+        }
+
+        /**
+         * Get the default size for the given preset.
+         */
+        private int getDefaultSize(TunnelsPreset preset) {
+            return preset == TunnelsPreset.CLEAR ? 50 : 9;
+        }
+    }
+
+    /**
+     * Helper class for tunnel network generation logic, shared between command and game tests.
+     *
+     * All presets are built on top of the same grid layout:
+     * cable planes at even Y levels, and a checkerboard of cables and free "cells" at odd Y levels.
+     * Every cell is a free position that is surrounded by cables of a single network,
+     * so it can hold a container that is observed or targeted by parts on the surrounding cables.
+     */
+    public static class TunnelsGenerationHelper {
+
+        /**
+         * Item types used to fill up the generated containers.
+         */
+        public static final List<Item> ITEM_POOL = Lists.newArrayList(
+                Items.STONE, Items.COBBLESTONE, Items.DIRT, Items.SAND, Items.GRAVEL,
+                Items.OAK_LOG, Items.BIRCH_LOG, Items.SPRUCE_LOG, Items.IRON_INGOT, Items.GOLD_INGOT,
+                Items.DIAMOND, Items.EMERALD, Items.REDSTONE, Items.COAL, Items.CHARCOAL,
+                Items.APPLE, Items.BREAD, Items.WHEAT, Items.CARROT, Items.POTATO,
+                Items.WHITE_WOOL, Items.RED_WOOL, Items.BLUE_WOOL, Items.GREEN_WOOL, Items.GLASS,
+                Items.OBSIDIAN, Items.NETHERRACK, Items.QUARTZ, Items.LAPIS_LAZULI, Items.FLINT,
+                Items.BONE, Items.STRING, Items.FEATHER, Items.LEATHER, Items.PAPER,
+                Items.BOOK, Items.STICK, Items.TORCH, Items.CLAY_BALL, Items.SUGAR
+        );
+
+        /**
+         * The item that is placed into and broken out of the world by the world block churn preset.
+         */
+        public static final Item CHURN_BLOCK_ITEM = Items.COBBLESTONE;
+
+        /**
+         * The number of distinct item types that are inserted into each regular storage container.
+         */
+        public static final int DEFAULT_VARIETY = 9;
+
+        /**
+         * The number of cells that the "deep" preset uses.
+         */
+        public static final int DEEP_CELLS = 16;
+
+        /**
+         * The amount of fluid that is inserted into each generated fluid container.
+         */
+        private static final int FLUID_AMOUNT = 1_000;
+
+        /**
+         * The amount of energy that is inserted into each generated energy container.
+         */
+        private static final int ENERGY_AMOUNT = 10_000;
+
+        /**
+         * Generate the given preset.
+         * @param preset The preset to generate.
+         * @param level The level to generate in.
+         * @param startPos The lowest corner of the generated grid.
+         * @param size The edge length of the generated grid.
+         */
+        public static void generate(TunnelsPreset preset, ServerLevel level, BlockPos startPos, int size) {
+            switch (preset) {
+                case EMPTY -> generateEmptyGrid(level, startPos, size);
+                case ITEMINTERFACES -> generateItemInterfaces(level, startPos, size);
+                case FLUIDINTERFACES -> generateFluidInterfaces(level, startPos, size);
+                case ENERGYINTERFACES -> generateEnergyInterfaces(level, startPos, size);
+                case ITEMINTERFACESDEEP -> generateItemInterfacesDeep(level, startPos, size);
+                case ITEMTRANSFER -> generateItemTransfer(level, startPos, size);
+                case FLUIDTRANSFER -> generateFluidTransfer(level, startPos, size);
+                case ENERGYTRANSFER -> generateEnergyTransfer(level, startPos, size);
+                case ITEMTRANSFERPREDICATE -> generateItemTransferPredicate(level, startPos, size);
+                case ITEMFILTERINGINTERFACES -> generateItemFilteringInterfaces(level, startPos, size);
+                case ITEMINDEXQUERY -> generateItemIndexQuery(level, startPos, size);
+                case WORLDBLOCKCHURN -> generateWorldBlockChurn(level, startPos, size);
+                case WORLDENTITYITEMCHURN -> generateWorldEntityItemChurn(level, startPos, size);
+                case PLAYERSIMULATORS -> generatePlayerSimulators(level, startPos, size);
+                case CLEAR -> clearGrid(level, startPos, size);
+            }
+        }
+
+        /**
+         * Generate a grid of cables without any parts or containers.
+         * @param level The level to generate in.
+         * @param startPos The lowest corner of the generated grid.
+         * @param size The edge length of the generated grid.
+         */
+        public static void generateEmptyGrid(ServerLevel level, BlockPos startPos, int size) {
+            List<BlockPos> placedPositions = Lists.newArrayList();
+
+            // Place all cables at once without triggering a network init for each of them,
+            // as that would make generation unusably slow for larger sizes.
+            BlockCable.SKIP_NETWORK_INIT = true;
+            try {
+                for (int x = 0; x < size; x++) {
+                    for (int y = 0; y < size; y++) {
+                        for (int z = 0; z < size; z++) {
+                            if (isCablePosition(x, y, z)) {
+                                BlockPos pos = startPos.offset(x, y, z);
+                                level.setBlock(pos, RegistryEntries.BLOCK_CABLE.value().defaultBlockState(), 2);
+                                placedPositions.add(pos);
+                            }
+                        }
+                    }
+                }
+            } finally {
+                BlockCable.SKIP_NETWORK_INIT = false;
+            }
+
+            for (BlockPos pos : placedPositions) {
+                CableHelpers.updateConnectionsNeighbours(level, pos, CableHelpers.ALL_SIDES);
+            }
+
+            NetworkHelpers.initNetwork(level, startPos, null);
+        }
+
+        /**
+         * @param x The local X coordinate within the grid.
+         * @param y The local Y coordinate within the grid.
+         * @param z The local Z coordinate within the grid.
+         * @return If a cable should be placed at the given local grid coordinate.
+         */
+        private static boolean isCablePosition(int x, int y, int z) {
+            // Even Y levels are fully filled with cables,
+            // odd Y levels alternate between cables and free cells.
+            return y % 2 == 0 || (x + z) % 2 == 0;
+        }
+
+        /**
+         * Get all cell positions of the grid, in a deterministic order.
+         *
+         * A cell is a free position at an odd Y level that is surrounded by cables,
+         * so that it can hold a container that is observed or targeted by the surrounding parts.
+         *
+         * @param startPos The lowest corner of the grid.
+         * @param size The edge length of the grid.
+         * @return The absolute cell positions.
+         */
+        public static List<BlockPos> getCells(BlockPos startPos, int size) {
+            List<BlockPos> cells = Lists.newArrayList();
+            for (int y = 1; y < size; y += 2) {
+                for (int x = 0; x < size; x++) {
+                    for (int z = 0; z < size; z++) {
+                        if (!isCablePosition(x, y, z)) {
+                            cells.add(startPos.offset(x, y, z));
+                        }
+                    }
+                }
+            }
+            return cells;
+        }
+
+        /**
+         * Get the direction from the given cell towards a horizontally neighbouring cable.
+         * @param level The level.
+         * @param cell A cell position.
+         * @return The direction, or null if the cell has no horizontally neighbouring cable.
+         */
+        @Nullable
+        public static Direction getSideCableDirection(ServerLevel level, BlockPos cell) {
+            for (Direction direction : Direction.Plane.HORIZONTAL) {
+                if (level.getBlockState(cell.relative(direction)).getBlock() == RegistryEntries.BLOCK_CABLE.value()) {
+                    return direction;
+                }
+            }
+            return null;
+        }
+
+        /**
+         * Add a part on the cable below the given cell, targeting the cell.
+         */
+        private static PartPos addPartBelow(ServerLevel level, BlockPos cell, IPartType partType) {
+            BlockPos cablePos = cell.below();
+            PartHelpers.addPart(level, cablePos, Direction.UP, partType, new ItemStack(partType.getItem()));
+            return PartPos.of(level, cablePos, Direction.UP);
+        }
+
+        /**
+         * Add a part on a cable next to the given cell, targeting the cell.
+         * @return The position of the added part, or null if the cell has no horizontal cable neighbour.
+         */
+        @Nullable
+        private static PartPos addPartBeside(ServerLevel level, BlockPos cell, IPartType partType) {
+            Direction sideDirection = getSideCableDirection(level, cell);
+            if (sideDirection == null) {
+                return null;
+            }
+            BlockPos cablePos = cell.relative(sideDirection);
+            Direction side = sideDirection.getOpposite();
+            PartHelpers.addPart(level, cablePos, side, partType, new ItemStack(partType.getItem()));
+            return PartPos.of(level, cablePos, side);
+        }
+
+        /**
+         * Enable the given aspect on the given part by inserting an empty variable.
+         */
+        private static void activate(ServerLevel level, PartPos partPos, IAspectWrite<?, ?> aspect) {
+            activate(level, partPos, aspect, new ItemStack(RegistryEntries.ITEM_VARIABLE));
+        }
+
+        /**
+         * Enable the given aspect on the given part by inserting a copy of the given variable.
+         */
+        private static void activate(ServerLevel level, PartPos partPos, IAspectWrite<?, ?> aspect, ItemStack variable) {
+            GameTestHelpersIntegratedDynamics.placeVariableInWriter(level, partPos, aspect, variable.copy());
+        }
+
+        /**
+         * Create a variable holding a predicate that matches the given item.
+         */
+        public static ItemStack createItemPredicate(ServerLevel level, Item item) {
+            return GameTestHelpersIntegratedDynamics.createVariableForValue(level, ValueTypes.OPERATOR,
+                    ValueTypeOperator.ValueOperator.of(new CurriedOperator(
+                            Operators.RELATIONAL_EQUALS,
+                            new Variable<>(ValueObjectTypeItemStack.ValueItemStack.of(new ItemStack(item)))
+                    )));
+        }
+
+        /**
+         * Create a full stack of the given item.
+         */
+        private static ItemStack createFullStack(Item item) {
+            ItemStack itemStack = new ItemStack(item);
+            itemStack.setCount(itemStack.getMaxStackSize());
+            return itemStack;
+        }
+
+        /**
+         * Place a chest at the given cell, and fill it with the given number of distinct item types.
+         * @param level The level.
+         * @param cell The cell position.
+         * @param variety The number of distinct item types to insert.
+         * @param itemOffset The offset within {@link #ITEM_POOL} to start inserting from.
+         */
+        public static void placeChest(ServerLevel level, BlockPos cell, int variety, int itemOffset) {
+            level.setBlock(cell, Blocks.CHEST.defaultBlockState(), 2);
+            if (variety <= 0) {
+                return;
+            }
+            if (level.getBlockEntity(cell) instanceof ChestBlockEntity chest) {
+                for (int slot = 0; slot < Math.min(variety, chest.getContainerSize()); slot++) {
+                    chest.setItem(slot, createFullStack(ITEM_POOL.get(Math.floorMod(itemOffset + slot, ITEM_POOL.size()))));
+                }
+            }
+        }
+
+        /**
+         * Place a chest at the given cell, and fill it completely with the given item.
+         */
+        public static void placeChestOf(ServerLevel level, BlockPos cell, Item item) {
+            level.setBlock(cell, Blocks.CHEST.defaultBlockState(), 2);
+            if (level.getBlockEntity(cell) instanceof ChestBlockEntity chest) {
+                for (int slot = 0; slot < chest.getContainerSize(); slot++) {
+                    chest.setItem(slot, createFullStack(item));
+                }
+            }
+        }
+
+        /**
+         * Place a drying basin at the given cell, optionally filled with water.
+         */
+        public static void placeFluidContainer(ServerLevel level, BlockPos cell, boolean filled) {
+            level.setBlock(cell, RegistryEntries.BLOCK_DRYING_BASIN.get().defaultBlockState(), 2);
+            if (filled && level.getBlockEntity(cell) instanceof BlockEntityDryingBasin basin) {
+                basin.getTank().setFluid(new FluidStack(Fluids.WATER, FLUID_AMOUNT));
+            }
+        }
+
+        /**
+         * Place an energy battery at the given cell, optionally filled with energy.
+         */
+        public static void placeEnergyContainer(ServerLevel level, BlockPos cell, boolean filled) {
+            level.setBlock(cell, RegistryEntries.BLOCK_ENERGY_BATTERY.get().defaultBlockState(), 2);
+            if (filled && level.getBlockEntity(cell) instanceof BlockEntityEnergyBattery battery) {
+                battery.setEnergyStored(ENERGY_AMOUNT);
+            }
+        }
+
+        /**
+         * Notify all cables around the given cells that their neighbours have changed,
+         * so that newly added parts and containers are picked up by the network.
+         */
+        private static void updateCells(ServerLevel level, List<BlockPos> cells) {
+            for (BlockPos cell : cells) {
+                for (Direction direction : Direction.values()) {
+                    BlockPos pos = cell.relative(direction);
+                    if (level.getBlockState(pos).getBlock() == RegistryEntries.BLOCK_CABLE.value()) {
+                        level.updateNeighborsAt(pos, RegistryEntries.BLOCK_CABLE.value());
+                    }
+                }
+            }
+        }
+
+        /**
+         * Generate a grid where every cell holds a filled chest that is exposed to the network
+         * by an item interface.
+         * This isolates the cost of the ingredient observer for the item channel.
+         */
+        public static void generateItemInterfaces(ServerLevel level, BlockPos startPos, int size) {
+            generateInterfaces(level, startPos, size, IngredientKind.ITEM, DEFAULT_VARIETY, false, 0);
+        }
+
+        /**
+         * Generate a grid where every cell holds a filled drying basin that is exposed to the network
+         * by a fluid interface.
+         */
+        public static void generateFluidInterfaces(ServerLevel level, BlockPos startPos, int size) {
+            generateInterfaces(level, startPos, size, IngredientKind.FLUID, DEFAULT_VARIETY, false, 0);
+        }
+
+        /**
+         * Generate a grid where every cell holds a filled energy battery that is exposed to the network
+         * by an energy interface.
+         */
+        public static void generateEnergyInterfaces(ServerLevel level, BlockPos startPos, int size) {
+            generateInterfaces(level, startPos, size, IngredientKind.ENERGY, DEFAULT_VARIETY, false, 0);
+        }
+
+        /**
+         * Generate a grid with only a few item interfaces, but with completely filled chests.
+         * Compared to {@link #generateItemInterfaces}, this shifts the observer cost
+         * from the number of observed positions to the number of observed slots.
+         */
+        public static void generateItemInterfacesDeep(ServerLevel level, BlockPos startPos, int size) {
+            generateInterfaces(level, startPos, size, IngredientKind.ITEM, Integer.MAX_VALUE, false, DEEP_CELLS);
+        }
+
+        /**
+         * Generate a grid where every cell holds a container that is exposed to the network by an interface.
+         * @param level The level.
+         * @param startPos The lowest corner of the grid.
+         * @param size The edge length of the grid.
+         * @param kind The ingredient kind to generate interfaces for.
+         * @param variety The number of distinct item types per container, for item containers.
+         * @param filtering If filtering interfaces should be used instead of regular interfaces.
+         * @param maxCells The maximum number of cells to use, or 0 for all cells.
+         */
+        private static void generateInterfaces(ServerLevel level, BlockPos startPos, int size, IngredientKind kind,
+                                               int variety, boolean filtering, int maxCells) {
+            generateEmptyGrid(level, startPos, size);
+
+            List<BlockPos> cells = getCells(startPos, size);
+            if (maxCells > 0 && cells.size() > maxCells) {
+                cells = cells.subList(0, maxCells);
+            }
+
+            for (int i = 0; i < cells.size(); i++) {
+                BlockPos cell = cells.get(i);
+                placeStorageContainer(level, cell, kind, variety, i * DEFAULT_VARIETY);
+                PartPos interfacePos = addPartBelow(level, cell, kind.getInterfacePartType(filtering));
+                if (filtering) {
+                    activate(level, interfacePos, kind.getBooleanFilterAspect());
+                }
+            }
+
+            updateCells(level, cells);
+        }
+
+        /**
+         * Place the storage container of the given ingredient kind at the given cell.
+         */
+        private static void placeStorageContainer(ServerLevel level, BlockPos cell, IngredientKind kind,
+                                                  int variety, int itemOffset) {
+            switch (kind) {
+                case ITEM -> placeChest(level, cell, variety, itemOffset);
+                case FLUID -> placeFluidContainer(level, cell, true);
+                case ENERGY -> placeEnergyContainer(level, cell, true);
+            }
+        }
+
+        /**
+         * Place an empty container of the given ingredient kind at the given cell.
+         */
+        private static void placeEmptyContainer(ServerLevel level, BlockPos cell, IngredientKind kind) {
+            switch (kind) {
+                case ITEM -> placeChest(level, cell, 0, 0);
+                case FLUID -> placeFluidContainer(level, cell, false);
+                case ENERGY -> placeEnergyContainer(level, cell, false);
+            }
+        }
+
+        /**
+         * Generate a grid where items are continuously moved between the network and the world.
+         */
+        public static void generateItemTransfer(ServerLevel level, BlockPos startPos, int size) {
+            generateTransfer(level, startPos, size, IngredientKind.ITEM, false, false);
+        }
+
+        /**
+         * Generate a grid where fluids are continuously moved between the network and the world.
+         */
+        public static void generateFluidTransfer(ServerLevel level, BlockPos startPos, int size) {
+            generateTransfer(level, startPos, size, IngredientKind.FLUID, false, false);
+        }
+
+        /**
+         * Generate a grid where energy is continuously moved between the network and the world.
+         */
+        public static void generateEnergyTransfer(ServerLevel level, BlockPos startPos, int size) {
+            generateTransfer(level, startPos, size, IngredientKind.ENERGY, false, false);
+        }
+
+        /**
+         * Generate a grid where items are continuously moved around, driven by predicate aspects.
+         * Compared to {@link #generateItemTransfer}, this additionally measures the cost of
+         * evaluating a predicate for every candidate ingredient.
+         */
+        public static void generateItemTransferPredicate(ServerLevel level, BlockPos startPos, int size) {
+            generateTransfer(level, startPos, size, IngredientKind.ITEM, true, false);
+        }
+
+        /**
+         * Generate a grid where items are continuously moved around,
+         * with filtering item interfaces as network storage.
+         */
+        public static void generateItemFilteringInterfaces(ServerLevel level, BlockPos startPos, int size) {
+            generateTransfer(level, startPos, size, IngredientKind.ITEM, false, true);
+        }
+
+        /**
+         * Generate a grid where every other cell is network storage,
+         * and the remaining cells continuously export ingredients out of the network and import them back.
+         * @param level The level.
+         * @param startPos The lowest corner of the grid.
+         * @param size The edge length of the grid.
+         * @param kind The ingredient kind to transfer.
+         * @param predicate If predicate aspects should be used instead of boolean aspects.
+         * @param filtering If filtering interfaces should be used as storage.
+         */
+        private static void generateTransfer(ServerLevel level, BlockPos startPos, int size, IngredientKind kind,
+                                             boolean predicate, boolean filtering) {
+            generateEmptyGrid(level, startPos, size);
+
+            List<BlockPos> cells = getCells(startPos, size);
+            for (int i = 0; i < cells.size(); i++) {
+                BlockPos cell = cells.get(i);
+                if (i % 2 == 0) {
+                    // Storage cell
+                    placeStorageContainer(level, cell, kind, DEFAULT_VARIETY, i * DEFAULT_VARIETY);
+                    PartPos interfacePos = addPartBelow(level, cell, kind.getInterfacePartType(filtering));
+                    if (filtering) {
+                        activate(level, interfacePos, kind.getBooleanFilterAspect());
+                    }
+                } else {
+                    // Churn cell: export out of the network, and import back in
+                    placeEmptyContainer(level, cell, kind);
+
+                    PartPos exporter = addPartBelow(level, cell, kind.getExporterPartType());
+                    PartPos importer = addPartBeside(level, cell, kind.getImporterPartType());
+                    if (predicate) {
+                        ItemStack itemPredicate = createItemPredicate(level, ITEM_POOL.get(Math.floorMod(i, ITEM_POOL.size())));
+                        activate(level, exporter, TunnelAspects.Write.Item.PREDICATE_EXPORT, itemPredicate);
+                        if (importer != null) {
+                            activate(level, importer, TunnelAspects.Write.Item.PREDICATE_IMPORT, itemPredicate);
+                        }
+                    } else {
+                        activate(level, exporter, kind.getBooleanExportAspect());
+                        if (importer != null) {
+                            activate(level, importer, kind.getBooleanImportAspect());
+                        }
+                    }
+                }
+            }
+
+            updateCells(level, cells);
+        }
+
+        /**
+         * Generate a grid where a large number of item interfaces hold distinct item types,
+         * and where a part of the cells continuously queries specific itemstacks out of the resulting index.
+         */
+        public static void generateItemIndexQuery(ServerLevel level, BlockPos startPos, int size) {
+            generateEmptyGrid(level, startPos, size);
+
+            List<BlockPos> cells = getCells(startPos, size);
+            for (int i = 0; i < cells.size(); i++) {
+                BlockPos cell = cells.get(i);
+                if (i % 4 == 3) {
+                    // Query cell: export one specific itemstack out of the network, and import it back
+                    placeChest(level, cell, 0, 0);
+                    Item queriedItem = ITEM_POOL.get(Math.floorMod(i, ITEM_POOL.size()));
+                    PartPos exporter = addPartBelow(level, cell, PartTypes.EXPORTER_ITEM);
+                    activate(level, exporter, TunnelAspects.Write.Item.ITEMSTACK_EXPORT,
+                            GameTestHelpersIntegratedDynamics.createVariableForValue(level, ValueTypes.OBJECT_ITEMSTACK,
+                                    ValueObjectTypeItemStack.ValueItemStack.of(new ItemStack(queriedItem))));
+                    PartPos importer = addPartBeside(level, cell, PartTypes.IMPORTER_ITEM);
+                    if (importer != null) {
+                        activate(level, importer, TunnelAspects.Write.Item.BOOLEAN_IMPORT);
+                    }
+                } else {
+                    // Storage cell, holding a distinct set of item types
+                    placeChest(level, cell, DEFAULT_VARIETY, i * DEFAULT_VARIETY);
+                    addPartBelow(level, cell, PartTypes.INTERFACE_ITEM);
+                }
+            }
+
+            updateCells(level, cells);
+        }
+
+        /**
+         * Generate a grid where world block exporters continuously place blocks into the cells,
+         * and world block importers break them again.
+         */
+        public static void generateWorldBlockChurn(ServerLevel level, BlockPos startPos, int size) {
+            generateEmptyGrid(level, startPos, size);
+
+            List<BlockPos> cells = getCells(startPos, size);
+            for (int i = 0; i < cells.size(); i++) {
+                BlockPos cell = cells.get(i);
+                if (i % 2 == 0) {
+                    // Storage cell, holding the blocks that are being placed
+                    placeChestOf(level, cell, CHURN_BLOCK_ITEM);
+                    addPartBelow(level, cell, PartTypes.INTERFACE_ITEM);
+                } else {
+                    // Churn cell: place a block into the cell, and break it again
+                    PartPos exporter = addPartBelow(level, cell, PartTypes.EXPORTER_WORLD_BLOCK);
+                    activate(level, exporter, TunnelAspects.Write.World.BLOCK_BOOLEAN_EXPORT);
+                    PartPos importer = addPartBeside(level, cell, PartTypes.IMPORTER_WORLD_BLOCK);
+                    if (importer != null) {
+                        activate(level, importer, TunnelAspects.Write.World.BLOCK_BOOLEAN_IMPORT);
+                    }
+                }
+            }
+
+            updateCells(level, cells);
+        }
+
+        /**
+         * Generate a grid where world entity item exporters continuously drop items into the cells,
+         * and world entity item importers pick them up again.
+         */
+        public static void generateWorldEntityItemChurn(ServerLevel level, BlockPos startPos, int size) {
+            generateEmptyGrid(level, startPos, size);
+
+            List<BlockPos> cells = getCells(startPos, size);
+            for (int i = 0; i < cells.size(); i++) {
+                BlockPos cell = cells.get(i);
+                if (i % 2 == 0) {
+                    // Storage cell, holding the items that are being dropped
+                    placeChest(level, cell, DEFAULT_VARIETY, i * DEFAULT_VARIETY);
+                    addPartBelow(level, cell, PartTypes.INTERFACE_ITEM);
+                } else {
+                    // Churn cell: drop items into the cell, and pick them up again
+                    PartPos exporter = addPartBelow(level, cell, PartTypes.EXPORTER_WORLD_ITEM);
+                    activate(level, exporter, TunnelAspects.Write.World.ENTITYITEM_BOOLEAN_EXPORT);
+                    PartPos importer = addPartBeside(level, cell, PartTypes.IMPORTER_WORLD_ITEM);
+                    if (importer != null) {
+                        activate(level, importer, TunnelAspects.Write.World.ENTITYITEM_BOOLEAN_IMPORT);
+                    }
+                }
+            }
+
+            updateCells(level, cells);
+        }
+
+        /**
+         * Generate a grid where player simulators continuously simulate right-clicks into the cells.
+         */
+        public static void generatePlayerSimulators(ServerLevel level, BlockPos startPos, int size) {
+            generateEmptyGrid(level, startPos, size);
+
+            List<BlockPos> cells = getCells(startPos, size);
+            for (int i = 0; i < cells.size(); i++) {
+                BlockPos cell = cells.get(i);
+                if (i % 2 == 0) {
+                    // Storage cell, so that the simulators operate on a realistic network
+                    placeChest(level, cell, DEFAULT_VARIETY, i * DEFAULT_VARIETY);
+                    addPartBelow(level, cell, PartTypes.INTERFACE_ITEM);
+                } else {
+                    PartPos simulator = addPartBelow(level, cell, PartTypes.PLAYER_SIMULATOR);
+                    activate(level, simulator, TunnelAspects.Write.Player.CLICK_EMPTY_BOOLEAN);
+                }
+            }
+
+            updateCells(level, cells);
+        }
+
+        /**
+         * Add an item interface with a filled chest at the given cell.
+         * This is used to measure the cost of growing a network at runtime.
+         * @param level The level.
+         * @param cell The cell to add an interface for.
+         * @param itemOffset The offset within {@link #ITEM_POOL} to start inserting from.
+         */
+        public static void addItemInterfaceCell(ServerLevel level, BlockPos cell, int itemOffset) {
+            placeChest(level, cell, DEFAULT_VARIETY, itemOffset);
+            addPartBelow(level, cell, PartTypes.INTERFACE_ITEM);
+            updateCells(level, Lists.newArrayList(cell));
+        }
+
+        /**
+         * Remove the container of the given cell, together with the cable that holds its part.
+         * This is used to measure the cost of shrinking a network at runtime.
+         * @param level The level.
+         * @param cell The cell to remove.
+         */
+        public static void removeCell(ServerLevel level, BlockPos cell) {
+            level.destroyBlock(cell, false);
+            level.destroyBlock(cell.below(), false);
+        }
+
+        /**
+         * Remove all blocks that the presets of this command can generate,
+         * within the given radius of the given position.
+         * @param level The level.
+         * @param centerPos The center position.
+         * @param radius The radius to clear.
+         */
+        public static void clearGrid(ServerLevel level, BlockPos centerPos, int radius) {
+            BlockCable.SKIP_NETWORK_INIT = true;
+
+            try {
+                for (int x = centerPos.getX() - radius; x <= centerPos.getX() + radius; x++) {
+                    for (int y = centerPos.getY() - radius; y <= centerPos.getY() + radius; y++) {
+                        for (int z = centerPos.getZ() - radius; z <= centerPos.getZ() + radius; z++) {
+                            BlockPos pos = new BlockPos(x, y, z);
+                            if (isGeneratedBlock(level.getBlockState(pos).getBlock())) {
+                                level.destroyBlock(pos, false);
+                            }
+                        }
+                    }
+                }
+            } finally {
+                BlockCable.SKIP_NETWORK_INIT = false;
+            }
+        }
+
+        /**
+         * @param block A block.
+         * @return If the given block is one that the presets of this command can generate.
+         */
+        private static boolean isGeneratedBlock(Block block) {
+            return block == RegistryEntries.BLOCK_CABLE.value()
+                    || block == Blocks.CHEST
+                    || block == RegistryEntries.BLOCK_DRYING_BASIN.get()
+                    || block == RegistryEntries.BLOCK_ENERGY_BATTERY.get()
+                    || block == Block.byItem(CHURN_BLOCK_ITEM);
+        }
+
+        /**
+         * The ingredient kinds that can be transferred over a network.
+         */
+        public enum IngredientKind {
+            ITEM,
+            FLUID,
+            ENERGY;
+
+            public IPartType getInterfacePartType(boolean filtering) {
+                return switch (this) {
+                    case ITEM -> filtering ? PartTypes.INTERFACE_FILTERING_ITEM : PartTypes.INTERFACE_ITEM;
+                    case FLUID -> filtering ? PartTypes.INTERFACE_FILTERING_FLUID : PartTypes.INTERFACE_FLUID;
+                    case ENERGY -> filtering ? PartTypes.INTERFACE_FILTERING_ENERGY : PartTypes.INTERFACE_ENERGY;
+                };
+            }
+
+            public IPartType getExporterPartType() {
+                return switch (this) {
+                    case ITEM -> PartTypes.EXPORTER_ITEM;
+                    case FLUID -> PartTypes.EXPORTER_FLUID;
+                    case ENERGY -> PartTypes.EXPORTER_ENERGY;
+                };
+            }
+
+            public IPartType getImporterPartType() {
+                return switch (this) {
+                    case ITEM -> PartTypes.IMPORTER_ITEM;
+                    case FLUID -> PartTypes.IMPORTER_FLUID;
+                    case ENERGY -> PartTypes.IMPORTER_ENERGY;
+                };
+            }
+
+            public IAspectWrite<?, ?> getBooleanExportAspect() {
+                return switch (this) {
+                    case ITEM -> TunnelAspects.Write.Item.BOOLEAN_EXPORT;
+                    case FLUID -> TunnelAspects.Write.Fluid.BOOLEAN_EXPORT;
+                    case ENERGY -> TunnelAspects.Write.Energy.BOOLEAN_EXPORT;
+                };
+            }
+
+            public IAspectWrite<?, ?> getBooleanImportAspect() {
+                return switch (this) {
+                    case ITEM -> TunnelAspects.Write.Item.BOOLEAN_IMPORT;
+                    case FLUID -> TunnelAspects.Write.Fluid.BOOLEAN_IMPORT;
+                    case ENERGY -> TunnelAspects.Write.Energy.BOOLEAN_IMPORT;
+                };
+            }
+
+            public IAspectWrite<?, ?> getBooleanFilterAspect() {
+                return switch (this) {
+                    case ITEM -> TunnelAspects.Write.ItemFilter.BOOLEAN_SET_FILTER;
+                    case FLUID -> TunnelAspects.Write.FluidFilter.BOOLEAN_SET_FILTER;
+                    case ENERGY -> TunnelAspects.Write.EnergyFilter.BOOLEAN_SET_FILTER;
+                };
+            }
+        }
+    }
+}

--- a/src/main/java/org/cyclops/integratedtunnels/gametest/GameTestsPerformance.java
+++ b/src/main/java/org/cyclops/integratedtunnels/gametest/GameTestsPerformance.java
@@ -1,0 +1,294 @@
+package org.cyclops.integratedtunnels.gametest;
+
+import com.google.common.math.Stats;
+import net.minecraft.core.BlockPos;
+import net.minecraft.gametest.framework.GameTest;
+import net.minecraft.gametest.framework.GameTestAssertException;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.util.TimeUtil;
+import net.neoforged.neoforge.gametest.GameTestHolder;
+import net.neoforged.neoforge.gametest.PrefixGameTestTemplate;
+import org.apache.logging.log4j.Level;
+import org.cyclops.cyclopscore.datastructure.Wrapper;
+import org.cyclops.integrateddynamics.core.network.diagnostics.NetworkDiagnostics;
+import org.cyclops.integratedtunnels.IntegratedTunnels;
+import org.cyclops.integratedtunnels.Reference;
+import org.cyclops.integratedtunnels.command.CommandGenerateTunnels;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+/**
+ * Game tests for performance benchmarking of tunnel operations.
+ * These tests generate networks with different presets and measure their performance.
+ * Results are written to runs/gameTestServer/logs/benchmark_results.txt for CI processing.
+ *
+ * These tests only do actual work when the PERFORMANCE_BENCHMARK_ENABLED environment variable is set,
+ * so that regular game test runs are not slowed down by them.
+ *
+ * @author rubensworks
+ */
+@GameTestHolder(Reference.MOD_ID)
+@PrefixGameTestTemplate(false)
+public class GameTestsPerformance {
+
+    public static final int EXECUTION_SECONDS = 10;
+    public static final int WARMUP_TICKS = 200;
+    public static final int TIMEOUT_TICKS = (EXECUTION_SECONDS + 20) * 20;
+    public static final int SIZE = 9; // Max 9, as the grid would otherwise leak out of the template.
+    public static final String TEMPLATE_EMPTY = "empty10";
+    public static final BlockPos START_POS = BlockPos.ZERO;
+
+    /**
+     * The number of cells that are added or removed after warming up, for the churn benchmarks.
+     */
+    public static final int CHURN_CELLS = 50;
+
+    private static final String RESULTS_FILE = "logs/benchmark_results.txt";
+
+    /**
+     * Check if performance benchmarking is enabled via environment variable.
+     *
+     * @return true if PERFORMANCE_BENCHMARK_ENABLED environment variable is set to "true"
+     */
+    private static boolean isBenchmarkingEnabled() {
+        // Check environment variable first
+        String envVar = System.getenv("PERFORMANCE_BENCHMARK_ENABLED");
+        if (envVar != null && "true".equalsIgnoreCase(envVar)) {
+            return true;
+        }
+
+        // Check system property as fallback
+        String sysProp = System.getProperty("PERFORMANCE_BENCHMARK_ENABLED");
+        return sysProp != null && "true".equalsIgnoreCase(sysProp);
+    }
+
+    static {
+        if (isBenchmarkingEnabled()) {
+            // Initialize empty file
+            writeResults(new ArrayList<>(), false);
+        }
+    }
+
+    /*
+     * Storage observation: the cost of the ingredient observers that watch the containers
+     * that interfaces expose to the network.
+     */
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = TIMEOUT_TICKS, batch = "performance_interfaces_item_idle")
+    public void testPerformanceItemInterfaces(GameTestHelper helper) {
+        testPerformance(helper, "interfaces_item_idle", (measureServerTickTimeNow) ->
+                CommandGenerateTunnels.TunnelsGenerationHelper.generateItemInterfaces(helper.getLevel(), helper.absolutePos(START_POS), SIZE));
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = TIMEOUT_TICKS, batch = "performance_interfaces_fluid_idle")
+    public void testPerformanceFluidInterfaces(GameTestHelper helper) {
+        testPerformance(helper, "interfaces_fluid_idle", (measureServerTickTimeNow) ->
+                CommandGenerateTunnels.TunnelsGenerationHelper.generateFluidInterfaces(helper.getLevel(), helper.absolutePos(START_POS), SIZE));
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = TIMEOUT_TICKS, batch = "performance_interfaces_energy_idle")
+    public void testPerformanceEnergyInterfaces(GameTestHelper helper) {
+        testPerformance(helper, "interfaces_energy_idle", (measureServerTickTimeNow) ->
+                CommandGenerateTunnels.TunnelsGenerationHelper.generateEnergyInterfaces(helper.getLevel(), helper.absolutePos(START_POS), SIZE));
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = TIMEOUT_TICKS, batch = "performance_interfaces_item_idle_deep")
+    public void testPerformanceItemInterfacesDeep(GameTestHelper helper) {
+        testPerformance(helper, "interfaces_item_idle_deep", (measureServerTickTimeNow) ->
+                CommandGenerateTunnels.TunnelsGenerationHelper.generateItemInterfacesDeep(helper.getLevel(), helper.absolutePos(START_POS), SIZE));
+    }
+
+    /*
+     * Active transfer: the cost of continuously moving ingredients between the network and the world.
+     */
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = TIMEOUT_TICKS, batch = "performance_items_transfer")
+    public void testPerformanceItemTransfer(GameTestHelper helper) {
+        testPerformance(helper, "items_transfer", (measureServerTickTimeNow) ->
+                CommandGenerateTunnels.TunnelsGenerationHelper.generateItemTransfer(helper.getLevel(), helper.absolutePos(START_POS), SIZE));
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = TIMEOUT_TICKS, batch = "performance_fluids_transfer")
+    public void testPerformanceFluidTransfer(GameTestHelper helper) {
+        testPerformance(helper, "fluids_transfer", (measureServerTickTimeNow) ->
+                CommandGenerateTunnels.TunnelsGenerationHelper.generateFluidTransfer(helper.getLevel(), helper.absolutePos(START_POS), SIZE));
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = TIMEOUT_TICKS, batch = "performance_energy_transfer")
+    public void testPerformanceEnergyTransfer(GameTestHelper helper) {
+        testPerformance(helper, "energy_transfer", (measureServerTickTimeNow) ->
+                CommandGenerateTunnels.TunnelsGenerationHelper.generateEnergyTransfer(helper.getLevel(), helper.absolutePos(START_POS), SIZE));
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = TIMEOUT_TICKS, batch = "performance_items_transfer_predicate")
+    public void testPerformanceItemTransferPredicate(GameTestHelper helper) {
+        testPerformance(helper, "items_transfer_predicate", (measureServerTickTimeNow) ->
+                CommandGenerateTunnels.TunnelsGenerationHelper.generateItemTransferPredicate(helper.getLevel(), helper.absolutePos(START_POS), SIZE));
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = TIMEOUT_TICKS, batch = "performance_items_filtering_interfaces")
+    public void testPerformanceItemFilteringInterfaces(GameTestHelper helper) {
+        testPerformance(helper, "items_filtering_interfaces", (measureServerTickTimeNow) ->
+                CommandGenerateTunnels.TunnelsGenerationHelper.generateItemFilteringInterfaces(helper.getLevel(), helper.absolutePos(START_POS), SIZE));
+    }
+
+    /*
+     * Index scaling: the cost of querying the network's ingredient index as it grows.
+     */
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = TIMEOUT_TICKS, batch = "performance_items_index_query")
+    public void testPerformanceItemIndexQuery(GameTestHelper helper) {
+        testPerformance(helper, "items_index_query", (measureServerTickTimeNow) ->
+                CommandGenerateTunnels.TunnelsGenerationHelper.generateItemIndexQuery(helper.getLevel(), helper.absolutePos(START_POS), SIZE));
+    }
+
+    /*
+     * Topology churn: the cost of registering and unregistering positions in the ingredient networks.
+     */
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = TIMEOUT_TICKS, batch = "performance_interfaces_item_append")
+    public void testPerformanceItemInterfacesAppend(GameTestHelper helper) {
+        testPerformance(helper, "interfaces_item_append", (measureServerTickTimeNow) -> {
+            CommandGenerateTunnels.TunnelsGenerationHelper.generateEmptyGrid(helper.getLevel(), helper.absolutePos(START_POS), SIZE);
+            addInterfacesPostWarmup(helper, CHURN_CELLS, WARMUP_TICKS);
+            // Measure server tick time right after the interfaces have been added
+            helper.runAfterDelay(WARMUP_TICKS + CHURN_CELLS, measureServerTickTimeNow);
+        });
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = TIMEOUT_TICKS, batch = "performance_interfaces_item_remove")
+    public void testPerformanceItemInterfacesRemove(GameTestHelper helper) {
+        testPerformance(helper, "interfaces_item_remove", (measureServerTickTimeNow) -> {
+            CommandGenerateTunnels.TunnelsGenerationHelper.generateItemInterfaces(helper.getLevel(), helper.absolutePos(START_POS), SIZE);
+            removeInterfacesPostWarmup(helper, CHURN_CELLS, WARMUP_TICKS);
+            // Measure server tick time right after the interfaces have been removed
+            helper.runAfterDelay(WARMUP_TICKS + CHURN_CELLS, measureServerTickTimeNow);
+        });
+    }
+
+    /*
+     * World-interacting parts: the cost of parts that mutate the world instead of a container.
+     */
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = TIMEOUT_TICKS, batch = "performance_world_block_churn")
+    public void testPerformanceWorldBlockChurn(GameTestHelper helper) {
+        testPerformance(helper, "world_block_churn", (measureServerTickTimeNow) ->
+                CommandGenerateTunnels.TunnelsGenerationHelper.generateWorldBlockChurn(helper.getLevel(), helper.absolutePos(START_POS), SIZE));
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = TIMEOUT_TICKS, batch = "performance_world_entityitem_churn")
+    public void testPerformanceWorldEntityItemChurn(GameTestHelper helper) {
+        testPerformance(helper, "world_entityitem_churn", (measureServerTickTimeNow) ->
+                CommandGenerateTunnels.TunnelsGenerationHelper.generateWorldEntityItemChurn(helper.getLevel(), helper.absolutePos(START_POS), SIZE));
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = TIMEOUT_TICKS, batch = "performance_player_simulator")
+    public void testPerformancePlayerSimulators(GameTestHelper helper) {
+        testPerformance(helper, "player_simulator", (measureServerTickTimeNow) ->
+                CommandGenerateTunnels.TunnelsGenerationHelper.generatePlayerSimulators(helper.getLevel(), helper.absolutePos(START_POS), SIZE));
+    }
+
+    /**
+     * Construct the given network, let it warm up, and measure its performance for {@link #EXECUTION_SECONDS}.
+     * @param helper The game test helper.
+     * @param networkName The name of the network preset, used as benchmark identifier.
+     * @param networkConstructor Constructs the network.
+     *                           It is passed a runnable that captures the server tick time at the moment it is called,
+     *                           which is useful for presets that only cause load during a part of the measurement.
+     */
+    public static void testPerformance(GameTestHelper helper, String networkName, Consumer<Runnable> networkConstructor) {
+        if (!isBenchmarkingEnabled()) {
+            IntegratedTunnels.clog(Level.INFO, "Performance benchmarking disabled (PERFORMANCE_BENCHMARK_ENABLED not set)");
+            helper.succeed();
+            return;
+        }
+
+        ensureResultsDirectory();
+
+        // Calculate average server-wide tick time
+        Wrapper<Double> avgServerTickTime = new Wrapper<>(0D);
+        Runnable measureServerTickTimeNow = () -> avgServerTickTime.set(Stats.meanOf(helper.getLevel().getServer().getTickTimesNanos()) / TimeUtil.NANOSECONDS_PER_MILLISECOND);
+        networkConstructor.accept(measureServerTickTimeNow);
+
+        // Measure the network performance
+        String measurementId = networkName + "_" + System.currentTimeMillis();
+        Wrapper<UUID> measurementUUID = new Wrapper<>();
+        helper.runAfterDelay(WARMUP_TICKS, () -> {
+            // Wait a few seconds to warm up the code before starting measurement
+            measurementUUID.set(NetworkDiagnostics.getInstance().startMeasurementWithoutPlayer(measurementId, EXECUTION_SECONDS));
+        });
+
+        // Wait for measurement to complete, then retrieve results
+        helper.succeedWhen(() -> {
+            if (measurementUUID.get() == null || !NetworkDiagnostics.getInstance().isMeasurementComplete(measurementUUID.get())) {
+                throw new GameTestAssertException("Measurement did not complete in time: " + measurementId);
+            }
+
+            double avgTickTime = NetworkDiagnostics.getInstance().getMeasurementAverageTickTime(measurementUUID.get());
+            NetworkDiagnostics.getInstance().clearMeasurement(measurementUUID.get());
+
+            // Calculate average server-wide tick time
+            if (avgServerTickTime.get() == 0D) {
+                measureServerTickTimeNow.run();
+            }
+
+            List<String> results = new ArrayList<>();
+            results.add(String.format("preset=%s size=%d avgNetworkTickTime=%.2f avgServerTickTime=%.2f", networkName, SIZE, avgTickTime, avgServerTickTime.get()));
+            writeResults(results, true);
+
+            CommandGenerateTunnels.TunnelsGenerationHelper.clearGrid(helper.getLevel(), helper.absolutePos(START_POS), SIZE);
+        });
+    }
+
+    private static void ensureResultsDirectory() {
+        try {
+            Files.createDirectories(Paths.get("logs"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static synchronized void writeResults(List<String> results, boolean append) {
+        try {
+            String content = String.join("\n", results);
+            if (append && Files.exists(Paths.get(RESULTS_FILE))) {
+                String existingString = Files.readString(Paths.get(RESULTS_FILE));
+                content = (existingString.isEmpty() ? content : existingString + content) + "\n";
+            }
+            Files.write(Paths.get(RESULTS_FILE), content.getBytes());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Add one item interface with a filled chest per tick, starting at the given delay.
+     */
+    private static void addInterfacesPostWarmup(GameTestHelper helper, int count, int delayOffset) {
+        List<BlockPos> cells = CommandGenerateTunnels.TunnelsGenerationHelper.getCells(helper.absolutePos(START_POS), SIZE);
+        for (int i = 0; i < Math.min(count, cells.size()); i++) {
+            final BlockPos cell = cells.get(i);
+            final int index = i;
+            helper.runAfterDelay(delayOffset + i, () -> CommandGenerateTunnels.TunnelsGenerationHelper
+                    .addItemInterfaceCell(helper.getLevel(), cell, index * CommandGenerateTunnels.TunnelsGenerationHelper.DEFAULT_VARIETY));
+        }
+    }
+
+    /**
+     * Remove one item interface with its chest per tick, starting at the given delay.
+     */
+    private static void removeInterfacesPostWarmup(GameTestHelper helper, int count, int delayOffset) {
+        List<BlockPos> cells = CommandGenerateTunnels.TunnelsGenerationHelper.getCells(helper.absolutePos(START_POS), SIZE);
+        for (int i = 0; i < Math.min(count, cells.size()); i++) {
+            final BlockPos cell = cells.get(i);
+            helper.runAfterDelay(delayOffset + i, () -> CommandGenerateTunnels.TunnelsGenerationHelper
+                    .removeCell(helper.getLevel(), cell));
+        }
+    }
+}


### PR DESCRIPTION
Adds a performance benchmarking setup mirroring the one of [Integrated Dynamics](https://github.com/CyclopsMC/IntegratedDynamics/blob/master-1.21-lts/PERFORMANCE_BENCHMARKING.md), measuring what Integrated Tunnels adds on top of a network: ingredient observation, ingredient transfer, index querying, and world interaction.

15 presets across 5 groups, each also exposed through a new `/integratedtunnels generatetunnels <preset> <size>` command for manual profiling.

Results are tracked under `CyclopsMC/IntegratedTunnels/<branch>/benchmarks` in `CyclopsMC/cyclops-performance-results`. The extra repository name segment compared to Integrated Dynamics is required, because both mods share branch names and would otherwise collide.

Note that the workflow's `if:` guard only runs the job on `master*` and `feature*` branches, so the first benchmark run happens once this is merged rather than on the PR itself.

## Grid layout

All presets share one layout so their results are comparable: cable planes at even Y, and a checkerboard of cables and free *cells* at odd Y. Every cell is surrounded by cables of a single network, so it can hold a container that is observed by an interface on the cable below it and simultaneously targeted by importers/exporters on the cables beside it. At size 9 (the largest that fits the game test template) that is 569 cables and 160 cells.

## Presets

**Storage observation** — `interfaces_item_idle`, `interfaces_fluid_idle`, `interfaces_energy_idle`, `interfaces_item_idle_deep`
**Active transfer** — `items_transfer`, `fluids_transfer`, `energy_transfer`, `items_transfer_predicate`, `items_filtering_interfaces`
**Index scaling** — `items_index_query`
**Topology churn** — `interfaces_item_append`, `interfaces_item_remove`
**World-interacting parts** — `world_block_churn`, `world_entityitem_churn`, `player_simulator`

## Validation

The presets were validated against a real run rather than only checked for existence, which surfaced three bugs that are fixed in this PR:

- **The predicate transfer preset transferred nothing at all.** Itemstack equality includes the stack size (`ItemMatch.EXACT` contains `ItemMatch.STACKSIZE`), so the general equality operator never matched the full stacks the generated containers are filled with. It now matches on the raw item, which takes the preset from 1.21 ms to 198.96 ms of network tick time, in line with the equivalent boolean preset.
- **The interface removal preset measured item entity ticking rather than network shrinking.** Removing a container block spills its contents into the world even when block drops are disabled, spawning 721 item entities. The container is now emptied first, which removes those entities entirely.
- **The "deep" storage observation preset was not deep**: it observed 432 slots against the regular preset's 1440. Its cell count is raised from 16 to 64, giving 1728 slots across fewer positions, which is what makes it shift cost from observed positions to observed slots.

That the transfer and churn presets really do churn continuously was verified by disabling the importers, after which all items, fluid, energy, placed blocks and dropped item entities accumulate as expected instead of round-tripping invisibly within a single tick.

## Results

`./gradlew runGameTestServer` without `PERFORMANCE_BENCHMARK_ENABLED` is unaffected: all 120 game tests pass in 13.9 s, with the 15 benchmarks returning immediately without generating anything. A full benchmark run takes about 7.5 minutes of wall clock.

| Preset | Network tick (ms) | Server tick (ms) |
| --- | ---: | ---: |
| `items_filtering_interfaces` | 211.34 | 7.58 |
| `items_transfer` | 207.88 | 7.94 |
| `items_transfer_predicate` | 198.96 | 8.15 |
| `items_index_query` | 89.24 | 7.84 |
| `energy_transfer` | 16.24 | 7.43 |
| `fluids_transfer` | 15.18 | 7.20 |
| `world_entityitem_churn` | 11.87 | 2.62 |
| `world_block_churn` | 7.49 | 6.48 |
| `player_simulator` | 0.46 | 5.76 |
| `interfaces_item_idle` | 0.14 | 8.80 |
| `interfaces_item_remove` | 0.03 | 36.84 |
| `interfaces_fluid_idle` | 0.01 | 5.62 |
| `interfaces_energy_idle` | 0.01 | 6.25 |
| `interfaces_item_idle_deep` | 0.00 | 2.28 |
| `interfaces_item_append` | 0.00 | 2.69 |

The idle and topology churn presets report a near-zero **network** tick time legitimately: ingredient observers are change-driven, so an idle network costs nothing per tick, and the append/remove presets amortise a 50-tick transient over a 10 second window. Their parts are verified to be present and active, so this is a property of what is being measured rather than a preset that failed to build. For those five, the server tick time is the meaningful signal, which is worth keeping in mind given that the benchmark action alerts on a relative threshold.