### PR TITLE
Auto-save interface settings when closing the gui

### DIFF
--- a/src/main/java/org/cyclops/integratedtunnels/core/part/ContainerScreenInterfaceSettings.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/part/ContainerScreenInterfaceSettings.java
@@ -58,8 +58,7 @@ public class ContainerScreenInterfaceSettings extends ContainerScreenPartSetting
 
         addRenderableWidget(new ButtonImage(this.leftPos - 20, this.topPos + 0, 18, 18,
                 Component.translatable("gui.integrateddynamics.part_offsets"),
-                createServerPressable(ContainerMultipartAspects.BUTTON_OFFSETS, (button) -> {
-                }),
+                createServerPressable(ContainerMultipartAspects.BUTTON_OFFSETS, (button) -> onSave()),
                 new IImage[]{
                         org.cyclops.integrateddynamics.client.gui.image.Images.BUTTON_BACKGROUND_INACTIVE,
                         org.cyclops.integrateddynamics.client.gui.image.Images.BUTTON_MIDDLE_OFFSET
@@ -67,6 +66,14 @@ public class ContainerScreenInterfaceSettings extends ContainerScreenPartSetting
                 false, 0, 0));
 
         this.refreshValues();
+    }
+
+    @Override
+    public void onClose() {
+        // Auto-save the settings when the gui is closed,
+        // so that the save button becomes optional.
+        onSave();
+        super.onClose();
     }
 
     @Override


### PR DESCRIPTION
Closes #161. Counterpart of CyclopsMC/IntegratedDynamics#1700, which does the same for the shared part settings and part offsets guis (readers, writers, …).

### Problem

In the interface settings gui, changes (such as the interface channel) were only persisted when the "Save" button was clicked. Because that button sits in the top-right corner, away from the fields, it is easy to assume it only applies to a single field, and closing the gui silently discarded everything that was typed.

### Change

`ContainerScreenInterfaceSettings` now saves automatically in the two cases where the gui goes away without the save button being used:

* `onClose()` calls `onSave()` before the container-close packet is sent, so the values are still applied to the part state server-side. This covers closing with Escape.
* The part-offsets button now passes `onSave()` as its client-side action, so the values are sent before the button packet makes the server swap in the offsets container. Without this, navigating to the offsets gui would also drop unsaved changes.

`onSave()` is the existing save path (it pushes the field values through the value notifier, which the server-side container turns into `updatePartSettings()`), so this reuses the exact same behaviour as the save button. The save button itself stays untouched, and still doubles as the way back to the part gui — pressing it is now optional rather than required.

### Relation to the Integrated Dynamics PR

CyclopsMC/IntegratedDynamics#1700 adds the same `onClose()` auto-save to the base `ContainerScreenPartSettings`. That makes the `onClose()` override in this PR redundant once the dependency is bumped, but it is kept so this fix also works against the currently pinned Integrated Dynamics version, and calling `onSave()` twice is a no-op (the value notifier skips unchanged values). The offsets-button save stays needed either way, since that button only exists here.

### Testing

* `./gradlew build` passes (includes `spotlessCheck`; the repo has no unit tests, and game tests only exist for MC 1.21+).
* The change is client-side gui code only, so it is not covered by automated tests; it was verified by reading through the save/value-notifier path rather than in-game.