### PR TITLE
Add match block option to world block importer aspects

### DIFF
--- a/src/main/java/org/cyclops/integratedtunnels/core/TunnelItemHelpers.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/TunnelItemHelpers.java
@@ -43,11 +43,6 @@ import java.util.Optional;
  */
 public class TunnelItemHelpers {
 
-    /**
-     * The maximum stack size that is imported at once when matching by block.
-     */
-    private static final int MATCH_BLOCK_DROPS_AMOUNT = 64;
-
     public static final IngredientPredicate<ItemStack, Integer> MATCH_NONE = new IngredientPredicate<ItemStack, Integer>(IngredientComponent.ITEMSTACK, ItemStack.EMPTY, ItemMatch.EXACT, false, true, 0, false) {
         @Override
         public boolean test(@Nullable ItemStack input) {
@@ -221,7 +216,7 @@ public class TunnelItemHelpers {
             if (!itemStackMatcher.test(BlockHelpers.getItemStackFromBlockState(destBlockState))) {
                 return null;
             }
-            itemStackMatcher = matchAll(MATCH_BLOCK_DROPS_AMOUNT, false);
+            itemStackMatcher = matchAll(itemStackMatcher.getMaxQuantity(), itemStackMatcher.isExactQuantity());
         }
 
         ItemStorageBlockWrapper sourceBlock = new ItemStorageBlockWrapper(

--- a/src/main/java/org/cyclops/integratedtunnels/core/TunnelItemHelpers.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/TunnelItemHelpers.java
@@ -13,6 +13,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import org.cyclops.commoncapabilities.api.capability.itemhandler.ItemMatch;
 import org.cyclops.commoncapabilities.api.ingredient.IngredientComponent;
 import org.cyclops.commoncapabilities.api.ingredient.storage.IIngredientComponentStorage;
+import org.cyclops.cyclopscore.helper.BlockHelpers;
 import org.cyclops.cyclopscore.helper.ItemStackHelpers;
 import org.cyclops.integrateddynamics.api.evaluate.EvaluationException;
 import org.cyclops.integrateddynamics.api.evaluate.operator.IOperator;
@@ -41,6 +42,11 @@ import java.util.Optional;
  * @author rubensworks
  */
 public class TunnelItemHelpers {
+
+    /**
+     * The maximum stack size that is imported at once when matching by block.
+     */
+    private static final int MATCH_BLOCK_DROPS_AMOUNT = 64;
 
     public static final IngredientPredicate<ItemStack, Integer> MATCH_NONE = new IngredientPredicate<ItemStack, Integer>(IngredientComponent.ITEMSTACK, ItemStack.EMPTY, ItemMatch.EXACT, false, true, 0, false) {
         @Override
@@ -191,6 +197,8 @@ public class TunnelItemHelpers {
      * @param fortune The fortune level.
      * @param silkTouch If the block should be broken with silk touch.
      * @param breakOnNoDrops If the block should be broken if it produced no drops.
+     * @param matchBlock If the item form of the to-be-broken block should be matched
+     *                   instead of the items that the block would drop.
      * @return The picked-up items.
      * @throws EvaluationException If illegal movement occured and further movement should stop.
      */
@@ -199,12 +207,21 @@ public class TunnelItemHelpers {
                                               IIngredientComponentStorage<ItemStack, Integer> destination,
                                               IngredientPredicate<ItemStack, Integer> itemStackMatcher, InteractionHand hand, boolean blockUpdate,
                                               boolean ignoreReplacable, int fortune, boolean silkTouch,
-                                              boolean breakOnNoDrops) throws EvaluationException {
+                                              boolean breakOnNoDrops, boolean matchBlock) throws EvaluationException {
         BlockState destBlockState = world.getBlockState(pos);
         final boolean isDestReplaceable = destBlockState.canBeReplaced(TunnelHelpers.createBlockItemUseContext(world, null, pos, side, hand));
         if (world.isEmptyBlock(pos)
                 || ((ignoreReplacable && isDestReplaceable) || destBlockState.liquid())) {
             return null;
+        }
+
+        // If we have to match by block, check the item form of the block that is present in the world.
+        // If it matches, all drops of that block are imported, no matter what they are.
+        if (matchBlock) {
+            if (!itemStackMatcher.test(BlockHelpers.getItemStackFromBlockState(destBlockState))) {
+                return null;
+            }
+            itemStackMatcher = matchAll(MATCH_BLOCK_DROPS_AMOUNT, false);
         }
 
         ItemStorageBlockWrapper sourceBlock = new ItemStorageBlockWrapper(

--- a/src/main/java/org/cyclops/integratedtunnels/gametest/GameTestHelpersIntegratedTunnels.java
+++ b/src/main/java/org/cyclops/integratedtunnels/gametest/GameTestHelpersIntegratedTunnels.java
@@ -43,4 +43,17 @@ public class GameTestHelpersIntegratedTunnels {
         partStateHolder.getState().setAspectProperties(aspect, properties);
     }
 
+    /**
+     * Configure the silk touch property of the given aspect within the given part.
+     * @param partPos The position of the part.
+     * @param aspect The active aspect of the part.
+     * @param silkTouch If blocks should be broken with silk touch.
+     */
+    public static void setSilkTouch(PartPos partPos, IAspectWrite<?, ?> aspect, boolean silkTouch) {
+        PartHelpers.PartStateHolder partStateHolder = PartHelpers.getPart(partPos);
+        IAspectProperties properties = aspect.getProperties(partStateHolder.getPart(), PartTarget.fromCenter(partPos), partStateHolder.getState());
+        properties.setValue(TunnelAspectWriteBuilders.World.PROP_SILK_TOUCH, ValueTypeBoolean.ValueBoolean.of(silkTouch));
+        partStateHolder.getState().setAspectProperties(aspect, properties);
+    }
+
 }

--- a/src/main/java/org/cyclops/integratedtunnels/gametest/GameTestHelpersIntegratedTunnels.java
+++ b/src/main/java/org/cyclops/integratedtunnels/gametest/GameTestHelpersIntegratedTunnels.java
@@ -30,4 +30,17 @@ public class GameTestHelpersIntegratedTunnels {
         partStateHolder.getState().setAspectProperties(aspect, properties);
     }
 
+    /**
+     * Configure the match block property of the given aspect within the given part.
+     * @param partPos The position of the part.
+     * @param aspect The active aspect of the part.
+     * @param matchBlock If the to-be-broken block should be matched instead of the items it would drop.
+     */
+    public static void setMatchBlock(PartPos partPos, IAspectWrite<?, ?> aspect, boolean matchBlock) {
+        PartHelpers.PartStateHolder partStateHolder = PartHelpers.getPart(partPos);
+        IAspectProperties properties = aspect.getProperties(partStateHolder.getPart(), PartTarget.fromCenter(partPos), partStateHolder.getState());
+        properties.setValue(TunnelAspectWriteBuilders.World.PROP_MATCH_BLOCK, ValueTypeBoolean.ValueBoolean.of(matchBlock));
+        partStateHolder.getState().setAspectProperties(aspect, properties);
+    }
+
 }

--- a/src/main/java/org/cyclops/integratedtunnels/gametest/GameTestsWorldBlock.java
+++ b/src/main/java/org/cyclops/integratedtunnels/gametest/GameTestsWorldBlock.java
@@ -29,6 +29,7 @@ import org.cyclops.integratedtunnels.part.aspect.TunnelAspects;
 import static org.cyclops.integrateddynamics.gametest.GameTestHelpersIntegratedDynamics.createVariableForValue;
 import static org.cyclops.integrateddynamics.gametest.GameTestHelpersIntegratedDynamics.placeVariableInWriter;
 import static org.cyclops.integratedtunnels.gametest.GameTestHelpersIntegratedTunnels.setMatchBlock;
+import static org.cyclops.integratedtunnels.gametest.GameTestHelpersIntegratedTunnels.setSilkTouch;
 
 @GameTestHolder(Reference.MOD_ID)
 @PrefixGameTestTemplate(false)
@@ -508,6 +509,23 @@ public class GameTestsWorldBlock {
             // Check that the predicate did not error
             IPartStateWriter partStateWriter = (IPartStateWriter) PartHelpers.getPart(importer).getState();
             helper.assertFalse(partStateWriter.isDeactivated(), "Importer is deactivated");
+        });
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = TIMEOUT)
+    public void testWorldBlockImporterMatchBlockSilkTouch(GameTestHelper helper) {
+        // Coal ore only drops itself when it is broken with silk touch.
+        setupImporterNetwork(helper, Blocks.COAL_ORE);
+
+        PartPos importer = PartPos.of(helper.getLevel(), helper.absolutePos(POS), Direction.WEST);
+        placeVariableInWriter(helper.getLevel(), importer, TunnelAspects.Write.World.BLOCK_BLOCK_IMPORT, createVariableForValue(helper.getLevel(), ValueTypes.OBJECT_BLOCK, ValueObjectTypeBlock.ValueBlock.of(Blocks.COAL_ORE.defaultBlockState())));
+        setMatchBlock(importer, TunnelAspects.Write.World.BLOCK_BLOCK_IMPORT, true);
+        setSilkTouch(importer, TunnelAspects.Write.World.BLOCK_BLOCK_IMPORT, true);
+
+        helper.succeedWhen(() -> {
+            // Check if the block is broken, and the silk touch drops are imported
+            helper.assertBlockNotPresent(Blocks.COAL_ORE, POS.west());
+            helper.assertContainerContains(POS.east().east(), Blocks.COAL_ORE.asItem());
         });
     }
 

--- a/src/main/java/org/cyclops/integratedtunnels/gametest/GameTestsWorldBlock.java
+++ b/src/main/java/org/cyclops/integratedtunnels/gametest/GameTestsWorldBlock.java
@@ -6,6 +6,7 @@ import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.ShulkerBoxBlockEntity;
 import net.neoforged.neoforge.gametest.GameTestHolder;
@@ -14,7 +15,11 @@ import org.cyclops.integrateddynamics.RegistryEntries;
 import org.cyclops.integrateddynamics.api.part.PartPos;
 import org.cyclops.integrateddynamics.api.part.write.IPartStateWriter;
 import org.cyclops.integrateddynamics.core.block.IgnoredBlockStatus;
+import org.cyclops.integrateddynamics.core.evaluate.operator.Operators;
+import org.cyclops.integrateddynamics.core.evaluate.variable.ValueObjectTypeBlock;
 import org.cyclops.integrateddynamics.core.evaluate.variable.ValueObjectTypeItemStack;
+import org.cyclops.integrateddynamics.core.evaluate.variable.ValueTypeList;
+import org.cyclops.integrateddynamics.core.evaluate.variable.ValueTypeOperator;
 import org.cyclops.integrateddynamics.core.evaluate.variable.ValueTypes;
 import org.cyclops.integrateddynamics.core.helper.PartHelpers;
 import org.cyclops.integratedtunnels.Reference;
@@ -23,6 +28,7 @@ import org.cyclops.integratedtunnels.part.aspect.TunnelAspects;
 
 import static org.cyclops.integrateddynamics.gametest.GameTestHelpersIntegratedDynamics.createVariableForValue;
 import static org.cyclops.integrateddynamics.gametest.GameTestHelpersIntegratedDynamics.placeVariableInWriter;
+import static org.cyclops.integratedtunnels.gametest.GameTestHelpersIntegratedTunnels.setMatchBlock;
 
 @GameTestHolder(Reference.MOD_ID)
 @PrefixGameTestTemplate(false)
@@ -309,6 +315,199 @@ public class GameTestsWorldBlock {
 
             // Restore original config
             org.cyclops.integratedtunnels.GeneralConfig.blockImporterBlacklist = originalBlacklist;
+        });
+    }
+
+    /**
+     * Set up a network with a world block importer facing the given block,
+     * and an item interface with a chest to store the imported items in.
+     * @param helper The game test helper.
+     * @param block The block to place in front of the importer.
+     */
+    private static void setupImporterNetwork(GameTestHelper helper, Block block) {
+        // Place cable
+        helper.setBlock(POS, RegistryEntries.BLOCK_CABLE.value());
+        helper.setBlock(POS.east(), RegistryEntries.BLOCK_CABLE.value());
+
+        // Place world block importer
+        PartHelpers.addPart(helper.getLevel(), helper.absolutePos(POS), Direction.WEST, PartTypes.IMPORTER_WORLD_BLOCK, new ItemStack(PartTypes.IMPORTER_WORLD_BLOCK.getItem()));
+
+        // Place item interface
+        PartHelpers.addPart(helper.getLevel(), helper.absolutePos(POS.east()), Direction.EAST, PartTypes.INTERFACE_ITEM, new ItemStack(PartTypes.INTERFACE_ITEM.getItem()));
+
+        // Place chest for interface
+        helper.setBlock(POS.east().east(), Blocks.CHEST);
+
+        // Place block before importer
+        helper.setBlock(POS.west(), block);
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = TIMEOUT)
+    public void testWorldBlockImporterMatchBlockBlockCorrect(GameTestHelper helper) {
+        // Stone drops cobblestone, so it can only be imported by matching the stone block itself.
+        setupImporterNetwork(helper, Blocks.STONE);
+
+        PartPos importer = PartPos.of(helper.getLevel(), helper.absolutePos(POS), Direction.WEST);
+        placeVariableInWriter(helper.getLevel(), importer, TunnelAspects.Write.World.BLOCK_BLOCK_IMPORT, createVariableForValue(helper.getLevel(), ValueTypes.OBJECT_BLOCK, ValueObjectTypeBlock.ValueBlock.of(Blocks.STONE.defaultBlockState())));
+        setMatchBlock(importer, TunnelAspects.Write.World.BLOCK_BLOCK_IMPORT, true);
+
+        helper.succeedWhen(() -> {
+            // Check if the block is broken, and its drops are imported
+            helper.assertBlockNotPresent(Blocks.STONE, POS.west());
+            helper.assertContainerContains(POS.east().east(), Items.COBBLESTONE);
+        });
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = TIMEOUT)
+    public void testWorldBlockImporterMatchBlockBlockIncorrect(GameTestHelper helper) {
+        // Stone drops cobblestone, but cobblestone must not match when the block itself is matched.
+        setupImporterNetwork(helper, Blocks.STONE);
+
+        PartPos importer = PartPos.of(helper.getLevel(), helper.absolutePos(POS), Direction.WEST);
+        placeVariableInWriter(helper.getLevel(), importer, TunnelAspects.Write.World.BLOCK_BLOCK_IMPORT, createVariableForValue(helper.getLevel(), ValueTypes.OBJECT_BLOCK, ValueObjectTypeBlock.ValueBlock.of(Blocks.COBBLESTONE.defaultBlockState())));
+        setMatchBlock(importer, TunnelAspects.Write.World.BLOCK_BLOCK_IMPORT, true);
+
+        helper.runAfterDelay(200, () -> {
+            // Check that the block is not broken
+            helper.assertBlockPresent(Blocks.STONE, POS.west());
+            helper.assertContainerEmpty(POS.east().east());
+            helper.succeed();
+        });
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = TIMEOUT)
+    public void testWorldBlockImporterMatchBlockDisabledMatchesDrops(GameTestHelper helper) {
+        // Without the match block option, the drops of the block are matched.
+        setupImporterNetwork(helper, Blocks.STONE);
+
+        PartPos importer = PartPos.of(helper.getLevel(), helper.absolutePos(POS), Direction.WEST);
+        placeVariableInWriter(helper.getLevel(), importer, TunnelAspects.Write.World.BLOCK_BLOCK_IMPORT, createVariableForValue(helper.getLevel(), ValueTypes.OBJECT_BLOCK, ValueObjectTypeBlock.ValueBlock.of(Blocks.COBBLESTONE.defaultBlockState())));
+        setMatchBlock(importer, TunnelAspects.Write.World.BLOCK_BLOCK_IMPORT, false);
+
+        helper.succeedWhen(() -> {
+            // Check if the block is broken, and its drops are imported
+            helper.assertBlockNotPresent(Blocks.STONE, POS.west());
+            helper.assertContainerContains(POS.east().east(), Items.COBBLESTONE);
+        });
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = TIMEOUT)
+    public void testWorldBlockImporterMatchBlockItemStackCorrect(GameTestHelper helper) {
+        setupImporterNetwork(helper, Blocks.STONE);
+
+        PartPos importer = PartPos.of(helper.getLevel(), helper.absolutePos(POS), Direction.WEST);
+        placeVariableInWriter(helper.getLevel(), importer, TunnelAspects.Write.World.BLOCK_ITEMSTACK_IMPORT, createVariableForValue(helper.getLevel(), ValueTypes.OBJECT_ITEMSTACK, ValueObjectTypeItemStack.ValueItemStack.of(new ItemStack(Blocks.STONE))));
+        setMatchBlock(importer, TunnelAspects.Write.World.BLOCK_ITEMSTACK_IMPORT, true);
+
+        helper.succeedWhen(() -> {
+            // Check if the block is broken, and its drops are imported
+            helper.assertBlockNotPresent(Blocks.STONE, POS.west());
+            helper.assertContainerContains(POS.east().east(), Items.COBBLESTONE);
+        });
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = TIMEOUT)
+    public void testWorldBlockImporterMatchBlockItemStackIncorrect(GameTestHelper helper) {
+        setupImporterNetwork(helper, Blocks.STONE);
+
+        PartPos importer = PartPos.of(helper.getLevel(), helper.absolutePos(POS), Direction.WEST);
+        placeVariableInWriter(helper.getLevel(), importer, TunnelAspects.Write.World.BLOCK_ITEMSTACK_IMPORT, createVariableForValue(helper.getLevel(), ValueTypes.OBJECT_ITEMSTACK, ValueObjectTypeItemStack.ValueItemStack.of(new ItemStack(Blocks.COBBLESTONE))));
+        setMatchBlock(importer, TunnelAspects.Write.World.BLOCK_ITEMSTACK_IMPORT, true);
+
+        helper.runAfterDelay(200, () -> {
+            // Check that the block is not broken
+            helper.assertBlockPresent(Blocks.STONE, POS.west());
+            helper.assertContainerEmpty(POS.east().east());
+            helper.succeed();
+        });
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = TIMEOUT)
+    public void testWorldBlockImporterMatchBlockListCorrect(GameTestHelper helper) {
+        setupImporterNetwork(helper, Blocks.STONE);
+
+        PartPos importer = PartPos.of(helper.getLevel(), helper.absolutePos(POS), Direction.WEST);
+        placeVariableInWriter(helper.getLevel(), importer, TunnelAspects.Write.World.BLOCK_LISTBLOCK_IMPORT, createVariableForValue(helper.getLevel(), ValueTypes.LIST, ValueTypeList.ValueList.ofAll(
+                ValueObjectTypeBlock.ValueBlock.of(Blocks.DIRT.defaultBlockState()),
+                ValueObjectTypeBlock.ValueBlock.of(Blocks.STONE.defaultBlockState())
+        )));
+        setMatchBlock(importer, TunnelAspects.Write.World.BLOCK_LISTBLOCK_IMPORT, true);
+
+        helper.succeedWhen(() -> {
+            // Check if the block is broken, and its drops are imported
+            helper.assertBlockNotPresent(Blocks.STONE, POS.west());
+            helper.assertContainerContains(POS.east().east(), Items.COBBLESTONE);
+        });
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = TIMEOUT)
+    public void testWorldBlockImporterMatchBlockListIncorrect(GameTestHelper helper) {
+        setupImporterNetwork(helper, Blocks.STONE);
+
+        PartPos importer = PartPos.of(helper.getLevel(), helper.absolutePos(POS), Direction.WEST);
+        placeVariableInWriter(helper.getLevel(), importer, TunnelAspects.Write.World.BLOCK_LISTBLOCK_IMPORT, createVariableForValue(helper.getLevel(), ValueTypes.LIST, ValueTypeList.ValueList.ofAll(
+                ValueObjectTypeBlock.ValueBlock.of(Blocks.DIRT.defaultBlockState()),
+                ValueObjectTypeBlock.ValueBlock.of(Blocks.COBBLESTONE.defaultBlockState())
+        )));
+        setMatchBlock(importer, TunnelAspects.Write.World.BLOCK_LISTBLOCK_IMPORT, true);
+
+        helper.runAfterDelay(200, () -> {
+            // Check that the block is not broken
+            helper.assertBlockPresent(Blocks.STONE, POS.west());
+            helper.assertContainerEmpty(POS.east().east());
+            helper.succeed();
+        });
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = TIMEOUT)
+    public void testWorldBlockImporterMatchBlockBoolean(GameTestHelper helper) {
+        // The match block option must not break importing all blocks.
+        setupImporterNetwork(helper, Blocks.STONE);
+
+        PartPos importer = PartPos.of(helper.getLevel(), helper.absolutePos(POS), Direction.WEST);
+        placeVariableInWriter(helper.getLevel(), importer, TunnelAspects.Write.World.BLOCK_BOOLEAN_IMPORT, new ItemStack(RegistryEntries.ITEM_VARIABLE));
+        setMatchBlock(importer, TunnelAspects.Write.World.BLOCK_BOOLEAN_IMPORT, true);
+
+        helper.succeedWhen(() -> {
+            // Check if the block is broken, and its drops are imported
+            helper.assertBlockNotPresent(Blocks.STONE, POS.west());
+            helper.assertContainerContains(POS.east().east(), Items.COBBLESTONE);
+        });
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = TIMEOUT)
+    public void testWorldBlockImporterMatchBlockWithoutItemDrops(GameTestHelper helper) {
+        // Coal ore does not drop itself, so it can only be imported by matching the block.
+        setupImporterNetwork(helper, Blocks.COAL_ORE);
+
+        PartPos importer = PartPos.of(helper.getLevel(), helper.absolutePos(POS), Direction.WEST);
+        placeVariableInWriter(helper.getLevel(), importer, TunnelAspects.Write.World.BLOCK_BLOCK_IMPORT, createVariableForValue(helper.getLevel(), ValueTypes.OBJECT_BLOCK, ValueObjectTypeBlock.ValueBlock.of(Blocks.COAL_ORE.defaultBlockState())));
+        setMatchBlock(importer, TunnelAspects.Write.World.BLOCK_BLOCK_IMPORT, true);
+
+        helper.succeedWhen(() -> {
+            // Check if the block is broken, and its drops are imported
+            helper.assertBlockNotPresent(Blocks.COAL_ORE, POS.west());
+            helper.assertContainerContains(POS.east().east(), Items.COAL);
+        });
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = TIMEOUT)
+    public void testWorldBlockImporterMatchBlockPredicate(GameTestHelper helper) {
+        // Coal ore drops coal, which is not a block, so block predicates can only match the block itself.
+        setupImporterNetwork(helper, Blocks.COAL_ORE);
+
+        PartPos importer = PartPos.of(helper.getLevel(), helper.absolutePos(POS), Direction.WEST);
+        placeVariableInWriter(helper.getLevel(), importer, TunnelAspects.Write.World.BLOCK_PREDICATEBLOCK_IMPORT, createVariableForValue(helper.getLevel(), ValueTypes.OPERATOR, ValueTypeOperator.ValueOperator.of(Operators.OBJECT_BLOCK_OPAQUE)));
+        setMatchBlock(importer, TunnelAspects.Write.World.BLOCK_PREDICATEBLOCK_IMPORT, true);
+
+        helper.succeedWhen(() -> {
+            // Check if the block is broken, and its drops are imported
+            helper.assertBlockNotPresent(Blocks.COAL_ORE, POS.west());
+            helper.assertContainerContains(POS.east().east(), Items.COAL);
+
+            // Check that the predicate did not error
+            IPartStateWriter partStateWriter = (IPartStateWriter) PartHelpers.getPart(importer).getState();
+            helper.assertFalse(partStateWriter.isDeactivated(), "Importer is deactivated");
         });
     }
 

--- a/src/main/java/org/cyclops/integratedtunnels/part/aspect/TunnelAspectWriteBuilders.java
+++ b/src/main/java/org/cyclops/integratedtunnels/part/aspect/TunnelAspectWriteBuilders.java
@@ -1343,6 +1343,8 @@ public class TunnelAspectWriteBuilders {
                 new AspectPropertyTypeInstance<>(ValueTypes.BOOLEAN, "aspect.aspecttypes.integratedtunnels.boolean.world.ignorereplacable");
         public static final IAspectPropertyTypeInstance<ValueTypeBoolean, ValueTypeBoolean.ValueBoolean> PROP_BREAK_ON_NO_DROPS =
                 new AspectPropertyTypeInstance<>(ValueTypes.BOOLEAN, "aspect.aspecttypes.integratedtunnels.boolean.world.breaknodrops");
+        public static final IAspectPropertyTypeInstance<ValueTypeBoolean, ValueTypeBoolean.ValueBoolean> PROP_MATCH_BLOCK =
+                new AspectPropertyTypeInstance<>(ValueTypes.BOOLEAN, "aspect.aspecttypes.integratedtunnels.boolean.world.matchblock");
         public static final IAspectPropertyTypeInstance<ValueTypeBoolean, ValueTypeBoolean.ValueBoolean> PROP_IGNORE_PICK_UP_DELAY =
                 new AspectPropertyTypeInstance<>(ValueTypes.BOOLEAN, "aspect.aspecttypes.integratedtunnels.boolean.world.ignorepickupdelay");
         public static final IAspectPropertyTypeInstance<ValueTypeBoolean, ValueTypeBoolean.ValueBoolean> PROP_DISPENSE =
@@ -2035,7 +2037,8 @@ public class TunnelAspectWriteBuilders {
                     PROP_HAND_RIGHT,
                     PROP_SILK_TOUCH,
                     PROP_IGNORE_REPLACABLE,
-                    PROP_BREAK_ON_NO_DROPS
+                    PROP_BREAK_ON_NO_DROPS,
+                    PROP_MATCH_BLOCK
             ));
             public static final IAspectProperties PROPERTIES_ITEM_PICK_UP = new AspectProperties(ImmutableList.<IAspectPropertyTypeInstance>of(
                     PROP_CHANNEL,
@@ -2047,7 +2050,8 @@ public class TunnelAspectWriteBuilders {
                     PROP_HAND_RIGHT,
                     PROP_SILK_TOUCH,
                     PROP_IGNORE_REPLACABLE,
-                    PROP_BREAK_ON_NO_DROPS
+                    PROP_BREAK_ON_NO_DROPS,
+                    PROP_MATCH_BLOCK
             ));
             public static final IAspectProperties PROPERTIES_ITEM_PICK_UP_NBT = new AspectProperties(ImmutableList.<IAspectPropertyTypeInstance>of(
                     PROP_CHANNEL,
@@ -2058,6 +2062,7 @@ public class TunnelAspectWriteBuilders {
                     PROP_SILK_TOUCH,
                     PROP_IGNORE_REPLACABLE,
                     PROP_BREAK_ON_NO_DROPS,
+                    PROP_MATCH_BLOCK,
                     TunnelAspectWriteBuilders.Item.PROP_NBT_SUBSET,
                     TunnelAspectWriteBuilders.Item.PROP_NBT_SUPERSET,
                     TunnelAspectWriteBuilders.Item.PROP_NBT_REQUIRE,
@@ -2077,7 +2082,8 @@ public class TunnelAspectWriteBuilders {
                     PROP_HAND_RIGHT,
                     PROP_SILK_TOUCH,
                     PROP_IGNORE_REPLACABLE,
-                    PROP_BREAK_ON_NO_DROPS
+                    PROP_BREAK_ON_NO_DROPS,
+                    PROP_MATCH_BLOCK
             ));
 
             static {
@@ -2115,6 +2121,7 @@ public class TunnelAspectWriteBuilders {
                 PROPERTIES_ITEM_PICK_UP_NOCHECKS.setValue(PROP_SILK_TOUCH, ValueTypeBoolean.ValueBoolean.of(false));
                 PROPERTIES_ITEM_PICK_UP_NOCHECKS.setValue(PROP_IGNORE_REPLACABLE, ValueTypeBoolean.ValueBoolean.of(false));
                 PROPERTIES_ITEM_PICK_UP_NOCHECKS.setValue(PROP_BREAK_ON_NO_DROPS, ValueTypeBoolean.ValueBoolean.of(true));
+                PROPERTIES_ITEM_PICK_UP_NOCHECKS.setValue(PROP_MATCH_BLOCK, ValueTypeBoolean.ValueBoolean.of(false));
 
                 PROPERTIES_ITEM_PICK_UP.setValue(PROP_CHANNEL, ValueTypeInteger.ValueInteger.of(IPositionedAddonsNetworkIngredients.DEFAULT_CHANNEL));
                 PROPERTIES_ITEM_PICK_UP.setValue(PROP_ROUNDROBIN, ValueTypeBoolean.ValueBoolean.of(false));
@@ -2126,6 +2133,7 @@ public class TunnelAspectWriteBuilders {
                 PROPERTIES_ITEM_PICK_UP.setValue(PROP_SILK_TOUCH, ValueTypeBoolean.ValueBoolean.of(false));
                 PROPERTIES_ITEM_PICK_UP.setValue(PROP_IGNORE_REPLACABLE, ValueTypeBoolean.ValueBoolean.of(false));
                 PROPERTIES_ITEM_PICK_UP.setValue(PROP_BREAK_ON_NO_DROPS, ValueTypeBoolean.ValueBoolean.of(true));
+                PROPERTIES_ITEM_PICK_UP.setValue(PROP_MATCH_BLOCK, ValueTypeBoolean.ValueBoolean.of(false));
 
                 PROPERTIES_ITEM_PICK_UP_NBT.setValue(PROP_CHANNEL, ValueTypeInteger.ValueInteger.of(IPositionedAddonsNetworkIngredients.DEFAULT_CHANNEL));
                 PROPERTIES_ITEM_PICK_UP_NBT.setValue(PROP_ROUNDROBIN, ValueTypeBoolean.ValueBoolean.of(false));
@@ -2135,6 +2143,7 @@ public class TunnelAspectWriteBuilders {
                 PROPERTIES_ITEM_PICK_UP_NBT.setValue(PROP_SILK_TOUCH, ValueTypeBoolean.ValueBoolean.of(false));
                 PROPERTIES_ITEM_PICK_UP_NBT.setValue(PROP_IGNORE_REPLACABLE, ValueTypeBoolean.ValueBoolean.of(false));
                 PROPERTIES_ITEM_PICK_UP_NBT.setValue(PROP_BREAK_ON_NO_DROPS, ValueTypeBoolean.ValueBoolean.of(true));
+                PROPERTIES_ITEM_PICK_UP_NBT.setValue(PROP_MATCH_BLOCK, ValueTypeBoolean.ValueBoolean.of(false));
                 PROPERTIES_ITEM_PICK_UP_NBT.setValue(TunnelAspectWriteBuilders.Item.PROP_NBT_SUBSET, ValueTypeBoolean.ValueBoolean.of(true));
                 PROPERTIES_ITEM_PICK_UP_NBT.setValue(TunnelAspectWriteBuilders.Item.PROP_NBT_SUPERSET, ValueTypeBoolean.ValueBoolean.of(true));
                 PROPERTIES_ITEM_PICK_UP_NBT.setValue(TunnelAspectWriteBuilders.Item.PROP_NBT_REQUIRE, ValueTypeBoolean.ValueBoolean.of(true));
@@ -2153,6 +2162,7 @@ public class TunnelAspectWriteBuilders {
                 PROPERTIES_BLOCK_PICK_UP.setValue(PROP_SILK_TOUCH, ValueTypeBoolean.ValueBoolean.of(false));
                 PROPERTIES_BLOCK_PICK_UP.setValue(PROP_IGNORE_REPLACABLE, ValueTypeBoolean.ValueBoolean.of(false));
                 PROPERTIES_BLOCK_PICK_UP.setValue(PROP_BREAK_ON_NO_DROPS, ValueTypeBoolean.ValueBoolean.of(true));
+                PROPERTIES_BLOCK_PICK_UP.setValue(PROP_MATCH_BLOCK, ValueTypeBoolean.ValueBoolean.of(false));
             }
             public static final IAspectProperties PROPERTIES_ITEM_PLACELIST = PROPERTIES_ITEMCRAFT_PLACE.clone();
             public static final IAspectProperties PROPERTIES_ITEM_PICK_UPLIST = PROPERTIES_ITEM_PICK_UP.clone();
@@ -2218,6 +2228,7 @@ public class TunnelAspectWriteBuilders {
                     int fortune = 0;
                     boolean silkTouch = input.getProperties().getValue(PROP_SILK_TOUCH).getRawValue();
                     boolean breakOnNoDrops = input.getProperties().getValue(PROP_BREAK_ON_NO_DROPS).getRawValue();
+                    boolean matchBlock = input.getProperties().getValue(PROP_MATCH_BLOCK).getRawValue();
                     TunnelItemHelpers.pickUpItems(
                             input.getNetwork(),
                             input.getChanneledNetwork(),
@@ -2233,7 +2244,8 @@ public class TunnelAspectWriteBuilders {
                             ignoreReplacable,
                             fortune,
                             silkTouch,
-                            breakOnNoDrops
+                            breakOnNoDrops,
+                            matchBlock
                     );
                 }
                 return null;

--- a/src/main/resources/assets/integratedtunnels/lang/en_us.json
+++ b/src/main/resources/assets/integratedtunnels/lang/en_us.json
@@ -133,6 +133,8 @@
   "aspect.aspecttypes.integratedtunnels.boolean.world.ignorereplacable": "Ignore Replacable",
   "aspect.aspecttypes.integratedtunnels.boolean.world.breaknodrops": "Break Block When No Drops",
   "aspect.aspecttypes.integratedtunnels.boolean.world.breaknodrops.info": "If the block should only be broken if it produces drops.",
+  "aspect.aspecttypes.integratedtunnels.boolean.world.matchblock": "Match Block",
+  "aspect.aspecttypes.integratedtunnels.boolean.world.matchblock.info": "If the aspect value should be matched against the item form of the block that is to be broken, instead of the items that the block would drop. All drops are imported when the block matches.",
   "aspect.aspecttypes.integratedtunnels.boolean.world.ignorepickupdelay": "Ignore Pickup Delay",
   "aspect.aspecttypes.integratedtunnels.boolean.world.dispense": "Dispense",
   "aspect.aspecttypes.integratedtunnels.double.world.offsetx": "Offset X",

--- a/src/main/resources/assets/integratedtunnels/lang/en_us.json
+++ b/src/main/resources/assets/integratedtunnels/lang/en_us.json
@@ -134,7 +134,7 @@
   "aspect.aspecttypes.integratedtunnels.boolean.world.breaknodrops": "Break Block When No Drops",
   "aspect.aspecttypes.integratedtunnels.boolean.world.breaknodrops.info": "If the block should only be broken if it produces drops.",
   "aspect.aspecttypes.integratedtunnels.boolean.world.matchblock": "Match Block",
-  "aspect.aspecttypes.integratedtunnels.boolean.world.matchblock.info": "If the aspect value should be matched against the item form of the block that is to be broken, instead of the items that the block would drop. All drops are imported when the block matches.",
+  "aspect.aspecttypes.integratedtunnels.boolean.world.matchblock.info": "Match item form of block instead dropped items",
   "aspect.aspecttypes.integratedtunnels.boolean.world.ignorepickupdelay": "Ignore Pickup Delay",
   "aspect.aspecttypes.integratedtunnels.boolean.world.dispense": "Dispense",
   "aspect.aspecttypes.integratedtunnels.double.world.offsetx": "Offset X",


### PR DESCRIPTION
Closes #347

## What

Adds a new **Match Block** aspect property to all eight World Block Importer aspects (`Pick Up All Item Blocks`, `Pick Up Item Block`, `Pick Up Item Blocks`, `Pick Up Item Blocks Predicate`, `Pick Up Item Blocks NBT`, `Pick Up Block`, `Pick Up Blocks`, `Pick Up Blocks Predicate`).

When enabled, the aspect value is matched against the **item form of the block that is present in the world**, instead of against the items that this block would drop. When the block matches, all of its drops are imported, whatever they are.

The property defaults to `false`, so existing setups keep their current behaviour. Aspect properties saved before this change fall back to the value type default (`false`) as well.

This makes the scenario from the issue work: a Grass Block can be broken by referring to the Grass Block itself, rather than by having to refer to the Dirt it drops. It also makes blocks that never drop themselves (ores, clusters, ...) addressable by their own identity.

The property was only added to the importer property sets; the World Block Exporter aspects are untouched.

## How

* `TunnelAspectWriteBuilders.World.PROP_MATCH_BLOCK`: new boolean property, added to `PROPERTIES_ITEM_PICK_UP_NOCHECKS`, `PROPERTIES_ITEM_PICK_UP`, `PROPERTIES_ITEM_PICK_UP_NBT` and `PROPERTIES_BLOCK_PICK_UP` (the `*LIST` / `*BLOCK` variants are clones of these).
* `PROP_ITEMBLOCK_IMPORT` reads the property and passes it to `TunnelItemHelpers.pickUpItems`.
* `TunnelItemHelpers.pickUpItems`: when `matchBlock` is set, the aspect's ingredient predicate is tested against `BlockHelpers.getItemStackFromBlockState` of the targeted block. If it does not match, nothing happens; if it matches, the predicate is replaced by a match-all predicate that inherits the amount and exactness of the aspect's own matcher, so that all drops are imported.
* Added the `matchblock` (+ `.info`) lang keys to `en_us.json`.

## Tests

Eleven new game tests in `GameTestsWorldBlock`, covering the block, item, list, predicate and boolean importer aspects: matching and non-matching values with the option enabled, the unchanged drop-matching behaviour with the option disabled, a block that does not drop itself (coal ore), and matching by block combined with silk-touch breaking.

`./gradlew build` and `./gradlew runGameTestServer` both pass (128/128 game tests).

## Note

While writing the tests I noticed an unrelated, pre-existing problem: blocks whose drops have a stack size larger than one (e.g. clay → 4 clay balls, redstone ore → 4-5 redstone) are broken by the World Block Importer but their drops do not end up in the network. This reproduces with the plain `Pick Up All Item Blocks` aspect on master, without any of the changes in this PR, so it is left alone here. It looks like it could be the cause of the amethyst/GeOre cluster reports in #347 and CyclopsMC/IntegratedDynamics#1702.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbYEGUuTvqvEiAvVAQqgrn