### PR TITLE
Make interfaces respect the target side configuration

### DIFF
--- a/src/main/java/org/cyclops/integratedtunnels/core/part/IPartTypeInterfacePositionedAddon.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/part/IPartTypeInterfacePositionedAddon.java
@@ -35,11 +35,32 @@ public interface IPartTypeInterfacePositionedAddon<N extends IPositionedAddonsNe
         return BlockEntityHelpers.getCapability(pos.getPos(), pos.getSide(), getTargetCapability());
     }
 
+    /**
+     * Determine the position that this interface should expose to the network for the given target.
+     *
+     * The target position that is passed around by the part lifecycle methods
+     * does not always take the part state's target side override and offset into account,
+     * so it is recalculated here based on the part state.
+     *
+     * As a side-effect, the center position is stored inside the given state,
+     * so that the target position can be recalculated at a later point in time,
+     * for example when the target side override changes.
+     *
+     * @param target The part target.
+     * @param state The part state.
+     * @return The effective target position.
+     */
+    public default PartPos getEffectiveTargetPos(PartTarget target, S state) {
+        PartTarget effectiveTarget = getTarget(target.getCenter(), state);
+        state.setCenter(effectiveTarget.getCenter());
+        return effectiveTarget.getTarget();
+    }
+
     public default void scheduleNetworkObservation(PartTarget target, S state) {
         IPositionedAddonsNetwork positionedAddonsNetwork = state.getPositionedAddonsNetwork();
         if (positionedAddonsNetwork instanceof IPositionedAddonsNetworkIngredients) {
             ((IPositionedAddonsNetworkIngredients) positionedAddonsNetwork).scheduleObservationForced(
-                    state.getChannelInterface(), target.getTarget());
+                    state.getChannelInterface(), getEffectiveTargetPos(target, state));
         }
     }
 
@@ -81,7 +102,11 @@ public interface IPartTypeInterfacePositionedAddon<N extends IPositionedAddonsNe
     }
 
     public default void removeTargetFromNetwork(INetwork network, PartPos pos, S state) {
-        removePositionFromNetwork(network, pos, state);
+        // Remove the position that was effectively added to the network before,
+        // as the given position may have changed in the meantime,
+        // for example when the target side override or offset was modified.
+        PartPos addedPos = state.getPos();
+        removePositionFromNetwork(network, addedPos != null ? addedPos : pos, state);
         state.setPositionedAddonsNetwork(null);
         state.setNetworks(null, null, null);
         state.setPos(null);
@@ -112,6 +137,22 @@ public interface IPartTypeInterfacePositionedAddon<N extends IPositionedAddonsNe
         public void setValidTargetCapability(boolean validTargetCapability);
         public PartPos getPos();
         public void setPos(PartPos pos);
+
+        /**
+         * @return The center position of this part, or null if it is not known (yet).
+         */
+        @Nullable
+        public default PartPos getCenter() {
+            return null;
+        }
+
+        /**
+         * Set the center position of this part.
+         * @param center The center position.
+         */
+        public default void setCenter(@Nullable PartPos center) {
+
+        }
 
         public default void disablePosition() {
             N positionedNetwork = getPositionedAddonsNetwork();

--- a/src/main/java/org/cyclops/integratedtunnels/core/part/IPartTypeInterfacePositionedAddon.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/part/IPartTypeInterfacePositionedAddon.java
@@ -81,6 +81,26 @@ public interface IPartTypeInterfacePositionedAddon<N extends IPositionedAddonsNe
 
     public void onRemovingPositionFromNetwork(N networkCapability, INetwork network, PartPos pos, S state);
 
+    /**
+     * @deprecated Use {@link #addTargetToNetwork(INetwork, PartTarget, int, int, IState)} instead,
+     *             which also keeps track of the part's center position.
+     */
+    @Deprecated // TODO: remove in next major
+    public default void addTargetToNetwork(INetwork network, PartPos posTarget, int priority, int channelInterface, S state) {
+        Pair<N, Boolean> ret = addPositionToNetwork(network, posTarget, priority, channelInterface, state);
+        N networkCapability = ret.getLeft();
+        boolean validTargetCapability = ret.getRight();
+        if (networkCapability != null) {
+            state.setPositionedAddonsNetwork(networkCapability);
+            state.setNetworks(network, NetworkHelpers.getPartNetworkChecked(network), ValueDeseralizationContext.of(posTarget.getPos().getLevel(true)));
+            state.setPos(posTarget);
+            state.setValidTargetCapability(validTargetCapability);
+            if (validTargetCapability) {
+                onAddingPositionToNetwork(networkCapability, network, posTarget, priority, channelInterface, state);
+            }
+        }
+    }
+
     public default void addTargetToNetwork(INetwork network, PartTarget target, int priority, int channelInterface, S state) {
         PartPos posTarget = getEffectiveTargetPos(target, state);
         Pair<N, Boolean> ret = addPositionToNetwork(network, posTarget, priority, channelInterface, state);
@@ -98,6 +118,15 @@ public interface IPartTypeInterfacePositionedAddon<N extends IPositionedAddonsNe
         }
     }
 
+    /**
+     * @deprecated Use {@link #removeTargetFromNetwork(INetwork, IState)} instead,
+     *             which always removes the position that was added before.
+     */
+    @Deprecated // TODO: remove in next major
+    public default void removeTargetFromNetwork(INetwork network, PartPos pos, S state) {
+        removeTargetFromNetwork(network, state);
+    }
+
     public default void removeTargetFromNetwork(INetwork network, S state) {
         // Remove the position that was added to the network before,
         // as the effective target position may have changed in the meantime,
@@ -110,6 +139,25 @@ public interface IPartTypeInterfacePositionedAddon<N extends IPositionedAddonsNe
         state.setNetworks(null, null, null);
         state.setPos(null);
         state.setValidTargetCapability(false);
+    }
+
+    /**
+     * @deprecated Use {@link #updateTargetInNetwork(INetwork, PartTarget, int, int, IState)} instead,
+     *             which also keeps track of the part's center position.
+     */
+    @Deprecated // TODO: remove in next major
+    public default void updateTargetInNetwork(INetwork network, PartPos pos, int priority, int channelInterface, S state) {
+        if (network.getCapability(getNetworkCapability()).isPresent()) {
+            boolean validTargetCapability = getTargetCapabilityInstance(pos)
+                    .map(this::isTargetCapabilityValid)
+                    .orElse(false);
+            boolean wasValidTargetCapability = state.isValidTargetCapability();
+            // Only trigger a change if the capability presence has changed.
+            if (validTargetCapability != wasValidTargetCapability) {
+                removeTargetFromNetwork(network, state);
+                addTargetToNetwork(network, pos, priority, channelInterface, state);
+            }
+        }
     }
 
     public default void updateTargetInNetwork(INetwork network, PartTarget target, int priority, int channelInterface, S state) {
@@ -140,6 +188,7 @@ public interface IPartTypeInterfacePositionedAddon<N extends IPositionedAddonsNe
         /**
          * @return The center position of this part, or null if this part was never added to a network.
          */
+        // TODO: make a non-default method in next major
         @Nullable
         public default PartPos getCenter() {
             return null;
@@ -149,6 +198,7 @@ public interface IPartTypeInterfacePositionedAddon<N extends IPositionedAddonsNe
          * Set the center position of this part.
          * @param center The center position.
          */
+        // TODO: make a non-default method in next major
         public default void setCenter(@Nullable PartPos center) {
 
         }

--- a/src/main/java/org/cyclops/integratedtunnels/core/part/IPartTypeInterfacePositionedAddon.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/part/IPartTypeInterfacePositionedAddon.java
@@ -38,22 +38,17 @@ public interface IPartTypeInterfacePositionedAddon<N extends IPositionedAddonsNe
     /**
      * Determine the position that this interface should expose to the network for the given target.
      *
-     * The target position that is passed around by the part lifecycle methods
-     * does not always take the part state's target side override and offset into account,
-     * so it is recalculated here based on the part state.
-     *
-     * As a side-effect, the center position is stored inside the given state,
-     * so that the target position can be recalculated at a later point in time,
-     * for example when the target side override changes.
+     * The target position inside the given target is not always up-to-date,
+     * as it does not take the part state's target side override and offset into account,
+     * such as when a network element is revalidated.
+     * That is why it is recalculated here based on the part state.
      *
      * @param target The part target.
      * @param state The part state.
      * @return The effective target position.
      */
     public default PartPos getEffectiveTargetPos(PartTarget target, S state) {
-        PartTarget effectiveTarget = getTarget(target.getCenter(), state);
-        state.setCenter(effectiveTarget.getCenter());
-        return effectiveTarget.getTarget();
+        return getTarget(target.getCenter(), state).getTarget();
     }
 
     public default void scheduleNetworkObservation(PartTarget target, S state) {
@@ -86,7 +81,8 @@ public interface IPartTypeInterfacePositionedAddon<N extends IPositionedAddonsNe
 
     public void onRemovingPositionFromNetwork(N networkCapability, INetwork network, PartPos pos, S state);
 
-    public default void addTargetToNetwork(INetwork network, PartPos posTarget, int priority, int channelInterface, S state) {
+    public default void addTargetToNetwork(INetwork network, PartTarget target, int priority, int channelInterface, S state) {
+        PartPos posTarget = getEffectiveTargetPos(target, state);
         Pair<N, Boolean> ret = addPositionToNetwork(network, posTarget, priority, channelInterface, state);
         N networkCapability = ret.getLeft();
         boolean validTargetCapability = ret.getRight();
@@ -94,6 +90,7 @@ public interface IPartTypeInterfacePositionedAddon<N extends IPositionedAddonsNe
             state.setPositionedAddonsNetwork(networkCapability);
             state.setNetworks(network, NetworkHelpers.getPartNetworkChecked(network), ValueDeseralizationContext.of(posTarget.getPos().getLevel(true)));
             state.setPos(posTarget);
+            state.setCenter(target.getCenter());
             state.setValidTargetCapability(validTargetCapability);
             if (validTargetCapability) {
                 onAddingPositionToNetwork(networkCapability, network, posTarget, priority, channelInterface, state);
@@ -101,28 +98,30 @@ public interface IPartTypeInterfacePositionedAddon<N extends IPositionedAddonsNe
         }
     }
 
-    public default void removeTargetFromNetwork(INetwork network, PartPos pos, S state) {
-        // Remove the position that was effectively added to the network before,
-        // as the given position may have changed in the meantime,
+    public default void removeTargetFromNetwork(INetwork network, S state) {
+        // Remove the position that was added to the network before,
+        // as the effective target position may have changed in the meantime,
         // for example when the target side override or offset was modified.
-        PartPos addedPos = state.getPos();
-        removePositionFromNetwork(network, addedPos != null ? addedPos : pos, state);
+        PartPos posTarget = state.getPos();
+        if (posTarget != null) {
+            removePositionFromNetwork(network, posTarget, state);
+        }
         state.setPositionedAddonsNetwork(null);
         state.setNetworks(null, null, null);
         state.setPos(null);
         state.setValidTargetCapability(false);
     }
 
-    public default void updateTargetInNetwork(INetwork network, PartPos pos, int priority, int channelInterface, S state) {
+    public default void updateTargetInNetwork(INetwork network, PartTarget target, int priority, int channelInterface, S state) {
         if (network.getCapability(getNetworkCapability()).isPresent()) {
-            boolean validTargetCapability = getTargetCapabilityInstance(pos)
+            boolean validTargetCapability = getTargetCapabilityInstance(getEffectiveTargetPos(target, state))
                     .map(this::isTargetCapabilityValid)
                     .orElse(false);
             boolean wasValidTargetCapability = state.isValidTargetCapability();
             // Only trigger a change if the capability presence has changed.
             if (validTargetCapability != wasValidTargetCapability) {
-                removeTargetFromNetwork(network, pos, state);
-                addTargetToNetwork(network, pos, priority, channelInterface, state);
+                removeTargetFromNetwork(network, state);
+                addTargetToNetwork(network, target, priority, channelInterface, state);
             }
         }
     }
@@ -139,7 +138,7 @@ public interface IPartTypeInterfacePositionedAddon<N extends IPositionedAddonsNe
         public void setPos(PartPos pos);
 
         /**
-         * @return The center position of this part, or null if it is not known (yet).
+         * @return The center position of this part, or null if this part was never added to a network.
          */
         @Nullable
         public default PartPos getCenter() {

--- a/src/main/java/org/cyclops/integratedtunnels/core/part/PartTypeInterfacePositionedAddon.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/part/PartTypeInterfacePositionedAddon.java
@@ -1,6 +1,7 @@
 package org.cyclops.integratedtunnels.core.part;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.core.Vec3i;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
@@ -93,20 +94,20 @@ public abstract class PartTypeInterfacePositionedAddon<N extends IPositionedAddo
     @Override
     public void afterNetworkReAlive(INetwork network, IPartNetwork partNetwork, PartTarget target, S state) {
         super.afterNetworkReAlive(network, partNetwork, target, state);
-        addTargetToNetwork(network, target.getTarget(), state.getPriority(), state.getChannelInterface(), state);
+        addTargetToNetwork(network, getEffectiveTargetPos(target, state), state.getPriority(), state.getChannelInterface(), state);
     }
 
     @Override
     public void onNetworkRemoval(INetwork network, IPartNetwork partNetwork, PartTarget target, S state) {
         super.onNetworkRemoval(network, partNetwork, target, state);
         scheduleNetworkObservation(target, state);
-        removeTargetFromNetwork(network, target.getTarget(), state);
+        removeTargetFromNetwork(network, getEffectiveTargetPos(target, state), state);
     }
 
     @Override
     public void onNetworkAddition(INetwork network, IPartNetwork partNetwork, PartTarget target, S state) {
         super.onNetworkAddition(network, partNetwork, target, state);
-        addTargetToNetwork(network, target.getTarget(), state.getPriority(), state.getChannelInterface(), state);
+        addTargetToNetwork(network, getEffectiveTargetPos(target, state), state.getPriority(), state.getChannelInterface(), state);
         scheduleNetworkObservation(target, state);
     }
 
@@ -114,7 +115,7 @@ public abstract class PartTypeInterfacePositionedAddon<N extends IPositionedAddo
     public void onBlockNeighborChange(INetwork network, IPartNetwork partNetwork, PartTarget target, S state, BlockGetter world, Block neighbourBlock, BlockPos neighbourBlockPos) {
         super.onBlockNeighborChange(network, partNetwork, target, state, world, neighbourBlock, neighbourBlockPos);
         if (network != null) {
-            updateTargetInNetwork(network, target.getTarget(), state.getPriority(), state.getChannelInterface(), state);
+            updateTargetInNetwork(network, getEffectiveTargetPos(target, state), state.getPriority(), state.getChannelInterface(), state);
         }
     }
 
@@ -122,9 +123,9 @@ public abstract class PartTypeInterfacePositionedAddon<N extends IPositionedAddo
     public void setPriorityAndChannel(INetwork network, IPartNetwork partNetwork, PartTarget target, S state, int priority, int channel) {
         // We need to do this because the energy network is not automagically aware of the priority changes,
         // so we have to re-add it.
-        removeTargetFromNetwork(network, target.getTarget(), state);
+        removeTargetFromNetwork(network, getEffectiveTargetPos(target, state), state);
         super.setPriorityAndChannel(network, partNetwork, target, state, priority, channel);
-        addTargetToNetwork(network, target.getTarget(), priority, state.getChannelInterface(), state);
+        addTargetToNetwork(network, getEffectiveTargetPos(target, state), priority, state.getChannelInterface(), state);
     }
 
     @Override
@@ -140,6 +141,21 @@ public abstract class PartTypeInterfacePositionedAddon<N extends IPositionedAddo
             addTargetToNetwork(network, getTarget(center, state).getTarget(), state.getPriority(), state.getChannelInterface(), state);
         }
         return ret;
+    }
+
+    @Override
+    public void setTargetSideOverride(S state, @Nullable Direction side) {
+        // Remove interface before changing the target side, and re-add after,
+        // because the target side determines the position of this interface in the network.
+        INetwork network = state.getNetwork();
+        PartPos center = state.getCenter();
+        if (network != null && center != null) {
+            removeTargetFromNetwork(network, getTarget(center, state).getTarget(), state);
+        }
+        super.setTargetSideOverride(state, side);
+        if (network != null && center != null) {
+            addTargetToNetwork(network, getTarget(center, state).getTarget(), state.getPriority(), state.getChannelInterface(), state);
+        }
     }
 
     @Override
@@ -162,6 +178,7 @@ public abstract class PartTypeInterfacePositionedAddon<N extends IPositionedAddo
 
         private N positionedAddonsNetwork = null;
         private PartPos pos = null;
+        private PartPos center = null;
         private boolean validTargetCapability = false;
         private int channelInterface = 0;
 
@@ -222,6 +239,17 @@ public abstract class PartTypeInterfacePositionedAddon<N extends IPositionedAddo
         @Override
         public void setPos(PartPos pos) {
             this.pos = pos;
+        }
+
+        @Nullable
+        @Override
+        public PartPos getCenter() {
+            return center;
+        }
+
+        @Override
+        public void setCenter(@Nullable PartPos center) {
+            this.center = center;
         }
 
         @Override

--- a/src/main/java/org/cyclops/integratedtunnels/core/part/PartTypeInterfacePositionedAddon.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/part/PartTypeInterfacePositionedAddon.java
@@ -94,20 +94,20 @@ public abstract class PartTypeInterfacePositionedAddon<N extends IPositionedAddo
     @Override
     public void afterNetworkReAlive(INetwork network, IPartNetwork partNetwork, PartTarget target, S state) {
         super.afterNetworkReAlive(network, partNetwork, target, state);
-        addTargetToNetwork(network, getEffectiveTargetPos(target, state), state.getPriority(), state.getChannelInterface(), state);
+        addTargetToNetwork(network, target, state.getPriority(), state.getChannelInterface(), state);
     }
 
     @Override
     public void onNetworkRemoval(INetwork network, IPartNetwork partNetwork, PartTarget target, S state) {
         super.onNetworkRemoval(network, partNetwork, target, state);
         scheduleNetworkObservation(target, state);
-        removeTargetFromNetwork(network, getEffectiveTargetPos(target, state), state);
+        removeTargetFromNetwork(network, state);
     }
 
     @Override
     public void onNetworkAddition(INetwork network, IPartNetwork partNetwork, PartTarget target, S state) {
         super.onNetworkAddition(network, partNetwork, target, state);
-        addTargetToNetwork(network, getEffectiveTargetPos(target, state), state.getPriority(), state.getChannelInterface(), state);
+        addTargetToNetwork(network, target, state.getPriority(), state.getChannelInterface(), state);
         scheduleNetworkObservation(target, state);
     }
 
@@ -115,7 +115,7 @@ public abstract class PartTypeInterfacePositionedAddon<N extends IPositionedAddo
     public void onBlockNeighborChange(INetwork network, IPartNetwork partNetwork, PartTarget target, S state, BlockGetter world, Block neighbourBlock, BlockPos neighbourBlockPos) {
         super.onBlockNeighborChange(network, partNetwork, target, state, world, neighbourBlock, neighbourBlockPos);
         if (network != null) {
-            updateTargetInNetwork(network, getEffectiveTargetPos(target, state), state.getPriority(), state.getChannelInterface(), state);
+            updateTargetInNetwork(network, target, state.getPriority(), state.getChannelInterface(), state);
         }
     }
 
@@ -123,9 +123,9 @@ public abstract class PartTypeInterfacePositionedAddon<N extends IPositionedAddo
     public void setPriorityAndChannel(INetwork network, IPartNetwork partNetwork, PartTarget target, S state, int priority, int channel) {
         // We need to do this because the energy network is not automagically aware of the priority changes,
         // so we have to re-add it.
-        removeTargetFromNetwork(network, getEffectiveTargetPos(target, state), state);
+        removeTargetFromNetwork(network, state);
         super.setPriorityAndChannel(network, partNetwork, target, state, priority, channel);
-        addTargetToNetwork(network, getEffectiveTargetPos(target, state), priority, state.getChannelInterface(), state);
+        addTargetToNetwork(network, target, priority, state.getChannelInterface(), state);
     }
 
     @Override
@@ -134,11 +134,11 @@ public abstract class PartTypeInterfacePositionedAddon<N extends IPositionedAddo
         // because the target offset might change the interface.
         INetwork network = state.getNetwork();
         if (network != null) {
-            removeTargetFromNetwork(network, getTarget(center, state).getTarget(), state);
+            removeTargetFromNetwork(network, state);
         }
         boolean ret = super.setTargetOffset(state, center, offset);
         if (network != null) {
-            addTargetToNetwork(network, getTarget(center, state).getTarget(), state.getPriority(), state.getChannelInterface(), state);
+            addTargetToNetwork(network, getTarget(center, state), state.getPriority(), state.getChannelInterface(), state);
         }
         return ret;
     }
@@ -150,11 +150,11 @@ public abstract class PartTypeInterfacePositionedAddon<N extends IPositionedAddo
         INetwork network = state.getNetwork();
         PartPos center = state.getCenter();
         if (network != null && center != null) {
-            removeTargetFromNetwork(network, getTarget(center, state).getTarget(), state);
+            removeTargetFromNetwork(network, state);
         }
         super.setTargetSideOverride(state, side);
         if (network != null && center != null) {
-            addTargetToNetwork(network, getTarget(center, state).getTarget(), state.getPriority(), state.getChannelInterface(), state);
+            addTargetToNetwork(network, getTarget(center, state), state.getPriority(), state.getChannelInterface(), state);
         }
     }
 

--- a/src/main/java/org/cyclops/integratedtunnels/core/part/PartTypeInterfacePositionedAddon.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/part/PartTypeInterfacePositionedAddon.java
@@ -138,7 +138,10 @@ public abstract class PartTypeInterfacePositionedAddon<N extends IPositionedAddo
         }
         boolean ret = super.setTargetOffset(state, center, offset);
         if (network != null) {
-            addTargetToNetwork(network, getTarget(center, state), state.getPriority(), state.getChannelInterface(), state);
+            PartTarget target = getTarget(center, state);
+            addTargetToNetwork(network, target, state.getPriority(), state.getChannelInterface(), state);
+            // Force an observation, so that the network index does not linger on the old target
+            scheduleNetworkObservation(target, state);
         }
         return ret;
     }
@@ -154,7 +157,10 @@ public abstract class PartTypeInterfacePositionedAddon<N extends IPositionedAddo
         }
         super.setTargetSideOverride(state, side);
         if (network != null && center != null) {
-            addTargetToNetwork(network, getTarget(center, state), state.getPriority(), state.getChannelInterface(), state);
+            PartTarget target = getTarget(center, state);
+            addTargetToNetwork(network, target, state.getPriority(), state.getChannelInterface(), state);
+            // Force an observation, so that the network index does not linger on the old target side
+            scheduleNetworkObservation(target, state);
         }
     }
 

--- a/src/main/java/org/cyclops/integratedtunnels/core/part/PartTypeInterfacePositionedAddonFiltering.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/part/PartTypeInterfacePositionedAddonFiltering.java
@@ -1,6 +1,8 @@
 package org.cyclops.integratedtunnels.core.part;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.core.Vec3i;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
@@ -97,20 +99,20 @@ public abstract class PartTypeInterfacePositionedAddonFiltering<N extends IPosit
     @Override
     public void afterNetworkReAlive(INetwork network, IPartNetwork partNetwork, PartTarget target, S state) {
         super.afterNetworkReAlive(network, partNetwork, target, state);
-        addTargetToNetwork(network, target.getTarget(), state.getPriority(), state.getChannelInterface(), state);
+        addTargetToNetwork(network, getEffectiveTargetPos(target, state), state.getPriority(), state.getChannelInterface(), state);
     }
 
     @Override
     public void onNetworkRemoval(INetwork network, IPartNetwork partNetwork, PartTarget target, S state) {
         super.onNetworkRemoval(network, partNetwork, target, state);
         scheduleNetworkObservation(target, state);
-        removeTargetFromNetwork(network, target.getTarget(), state);
+        removeTargetFromNetwork(network, getEffectiveTargetPos(target, state), state);
     }
 
     @Override
     public void onNetworkAddition(INetwork network, IPartNetwork partNetwork, PartTarget target, S state) {
         super.onNetworkAddition(network, partNetwork, target, state);
-        addTargetToNetwork(network, target.getTarget(), state.getPriority(), state.getChannelInterface(), state);
+        addTargetToNetwork(network, getEffectiveTargetPos(target, state), state.getPriority(), state.getChannelInterface(), state);
         scheduleNetworkObservation(target, state);
     }
 
@@ -118,7 +120,7 @@ public abstract class PartTypeInterfacePositionedAddonFiltering<N extends IPosit
     public void onBlockNeighborChange(INetwork network, IPartNetwork partNetwork, PartTarget target, S state, BlockGetter world, Block neighbourBlock, BlockPos neighbourBlockPos) {
         super.onBlockNeighborChange(network, partNetwork, target, state, world, neighbourBlock, neighbourBlockPos);
         if (network != null) {
-            updateTargetInNetwork(network, target.getTarget(), state.getPriority(), state.getChannelInterface(), state);
+            updateTargetInNetwork(network, getEffectiveTargetPos(target, state), state.getPriority(), state.getChannelInterface(), state);
         }
     }
 
@@ -126,9 +128,39 @@ public abstract class PartTypeInterfacePositionedAddonFiltering<N extends IPosit
     public void setPriorityAndChannel(INetwork network, IPartNetwork partNetwork, PartTarget target, S state, int priority, int channel) {
         // We need to do this because the energy network is not automagically aware of the priority changes,
         // so we have to re-add it.
-        removeTargetFromNetwork(network, target.getTarget(), state);
+        removeTargetFromNetwork(network, getEffectiveTargetPos(target, state), state);
         super.setPriorityAndChannel(network, partNetwork, target, state, priority, channel);
-        addTargetToNetwork(network, target.getTarget(), priority, state.getChannelInterface(), state);
+        addTargetToNetwork(network, getEffectiveTargetPos(target, state), priority, state.getChannelInterface(), state);
+    }
+
+    @Override
+    public boolean setTargetOffset(S state, PartPos center, Vec3i offset) {
+        // Remove interface before changing offset, and re-add after,
+        // because the target offset might change the interface.
+        INetwork network = state.getNetwork();
+        if (network != null) {
+            removeTargetFromNetwork(network, getTarget(center, state).getTarget(), state);
+        }
+        boolean ret = super.setTargetOffset(state, center, offset);
+        if (network != null) {
+            addTargetToNetwork(network, getTarget(center, state).getTarget(), state.getPriority(), state.getChannelInterface(), state);
+        }
+        return ret;
+    }
+
+    @Override
+    public void setTargetSideOverride(S state, @Nullable Direction side) {
+        // Remove interface before changing the target side, and re-add after,
+        // because the target side determines the position of this interface in the network.
+        INetwork network = state.getNetwork();
+        PartPos center = state.getCenter();
+        if (network != null && center != null) {
+            removeTargetFromNetwork(network, getTarget(center, state).getTarget(), state);
+        }
+        super.setTargetSideOverride(state, side);
+        if (network != null && center != null) {
+            addTargetToNetwork(network, getTarget(center, state).getTarget(), state.getPriority(), state.getChannelInterface(), state);
+        }
     }
 
     public static abstract class State<N extends IPositionedAddonsNetwork, T, P extends PartTypeInterfacePositionedAddonFiltering<N, T, P, S>, S extends PartTypeInterfacePositionedAddonFiltering.State<N, T, P, S>>
@@ -136,6 +168,7 @@ public abstract class PartTypeInterfacePositionedAddonFiltering<N extends IPosit
             implements IPartTypeInterfacePositionedAddon.IState<N, T, P, S> {
         private N positionedAddonsNetwork = null;
         private PartPos pos = null;
+        private PartPos center = null;
         private boolean validTargetCapability = false;
         private int channelInterface = 0;
 
@@ -208,6 +241,17 @@ public abstract class PartTypeInterfacePositionedAddonFiltering<N extends IPosit
         @Override
         public void setPos(PartPos pos) {
             this.pos = pos;
+        }
+
+        @Nullable
+        @Override
+        public PartPos getCenter() {
+            return center;
+        }
+
+        @Override
+        public void setCenter(@Nullable PartPos center) {
+            this.center = center;
         }
 
         public boolean isRequireAspectUpdateAndReset() {

--- a/src/main/java/org/cyclops/integratedtunnels/core/part/PartTypeInterfacePositionedAddonFiltering.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/part/PartTypeInterfacePositionedAddonFiltering.java
@@ -143,7 +143,10 @@ public abstract class PartTypeInterfacePositionedAddonFiltering<N extends IPosit
         }
         boolean ret = super.setTargetOffset(state, center, offset);
         if (network != null) {
-            addTargetToNetwork(network, getTarget(center, state), state.getPriority(), state.getChannelInterface(), state);
+            PartTarget target = getTarget(center, state);
+            addTargetToNetwork(network, target, state.getPriority(), state.getChannelInterface(), state);
+            // Force an observation, so that the network index does not linger on the old target
+            scheduleNetworkObservation(target, state);
         }
         return ret;
     }
@@ -159,7 +162,10 @@ public abstract class PartTypeInterfacePositionedAddonFiltering<N extends IPosit
         }
         super.setTargetSideOverride(state, side);
         if (network != null && center != null) {
-            addTargetToNetwork(network, getTarget(center, state), state.getPriority(), state.getChannelInterface(), state);
+            PartTarget target = getTarget(center, state);
+            addTargetToNetwork(network, target, state.getPriority(), state.getChannelInterface(), state);
+            // Force an observation, so that the network index does not linger on the old target side
+            scheduleNetworkObservation(target, state);
         }
     }
 

--- a/src/main/java/org/cyclops/integratedtunnels/core/part/PartTypeInterfacePositionedAddonFiltering.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/part/PartTypeInterfacePositionedAddonFiltering.java
@@ -99,20 +99,20 @@ public abstract class PartTypeInterfacePositionedAddonFiltering<N extends IPosit
     @Override
     public void afterNetworkReAlive(INetwork network, IPartNetwork partNetwork, PartTarget target, S state) {
         super.afterNetworkReAlive(network, partNetwork, target, state);
-        addTargetToNetwork(network, getEffectiveTargetPos(target, state), state.getPriority(), state.getChannelInterface(), state);
+        addTargetToNetwork(network, target, state.getPriority(), state.getChannelInterface(), state);
     }
 
     @Override
     public void onNetworkRemoval(INetwork network, IPartNetwork partNetwork, PartTarget target, S state) {
         super.onNetworkRemoval(network, partNetwork, target, state);
         scheduleNetworkObservation(target, state);
-        removeTargetFromNetwork(network, getEffectiveTargetPos(target, state), state);
+        removeTargetFromNetwork(network, state);
     }
 
     @Override
     public void onNetworkAddition(INetwork network, IPartNetwork partNetwork, PartTarget target, S state) {
         super.onNetworkAddition(network, partNetwork, target, state);
-        addTargetToNetwork(network, getEffectiveTargetPos(target, state), state.getPriority(), state.getChannelInterface(), state);
+        addTargetToNetwork(network, target, state.getPriority(), state.getChannelInterface(), state);
         scheduleNetworkObservation(target, state);
     }
 
@@ -120,7 +120,7 @@ public abstract class PartTypeInterfacePositionedAddonFiltering<N extends IPosit
     public void onBlockNeighborChange(INetwork network, IPartNetwork partNetwork, PartTarget target, S state, BlockGetter world, Block neighbourBlock, BlockPos neighbourBlockPos) {
         super.onBlockNeighborChange(network, partNetwork, target, state, world, neighbourBlock, neighbourBlockPos);
         if (network != null) {
-            updateTargetInNetwork(network, getEffectiveTargetPos(target, state), state.getPriority(), state.getChannelInterface(), state);
+            updateTargetInNetwork(network, target, state.getPriority(), state.getChannelInterface(), state);
         }
     }
 
@@ -128,9 +128,9 @@ public abstract class PartTypeInterfacePositionedAddonFiltering<N extends IPosit
     public void setPriorityAndChannel(INetwork network, IPartNetwork partNetwork, PartTarget target, S state, int priority, int channel) {
         // We need to do this because the energy network is not automagically aware of the priority changes,
         // so we have to re-add it.
-        removeTargetFromNetwork(network, getEffectiveTargetPos(target, state), state);
+        removeTargetFromNetwork(network, state);
         super.setPriorityAndChannel(network, partNetwork, target, state, priority, channel);
-        addTargetToNetwork(network, getEffectiveTargetPos(target, state), priority, state.getChannelInterface(), state);
+        addTargetToNetwork(network, target, priority, state.getChannelInterface(), state);
     }
 
     @Override
@@ -139,11 +139,11 @@ public abstract class PartTypeInterfacePositionedAddonFiltering<N extends IPosit
         // because the target offset might change the interface.
         INetwork network = state.getNetwork();
         if (network != null) {
-            removeTargetFromNetwork(network, getTarget(center, state).getTarget(), state);
+            removeTargetFromNetwork(network, state);
         }
         boolean ret = super.setTargetOffset(state, center, offset);
         if (network != null) {
-            addTargetToNetwork(network, getTarget(center, state).getTarget(), state.getPriority(), state.getChannelInterface(), state);
+            addTargetToNetwork(network, getTarget(center, state), state.getPriority(), state.getChannelInterface(), state);
         }
         return ret;
     }
@@ -155,11 +155,11 @@ public abstract class PartTypeInterfacePositionedAddonFiltering<N extends IPosit
         INetwork network = state.getNetwork();
         PartPos center = state.getCenter();
         if (network != null && center != null) {
-            removeTargetFromNetwork(network, getTarget(center, state).getTarget(), state);
+            removeTargetFromNetwork(network, state);
         }
         super.setTargetSideOverride(state, side);
         if (network != null && center != null) {
-            addTargetToNetwork(network, getTarget(center, state).getTarget(), state.getPriority(), state.getChannelInterface(), state);
+            addTargetToNetwork(network, getTarget(center, state), state.getPriority(), state.getChannelInterface(), state);
         }
     }
 

--- a/src/main/java/org/cyclops/integratedtunnels/part/aspect/TunnelAspectWriteBuilders.java
+++ b/src/main/java/org/cyclops/integratedtunnels/part/aspect/TunnelAspectWriteBuilders.java
@@ -134,7 +134,7 @@ public class TunnelAspectWriteBuilders {
                 if (partStateHolder.getState().getNetwork() != null) {
                     partType.addTargetToNetwork(
                             partStateHolder.getState().getNetwork(),
-                            target.getTarget(),
+                            partType.getEffectiveTargetPos(target, partState),
                             partStateHolder.getState().getPriority(),
                             partStateHolder.getState().getChannelInterface(),
                             partState

--- a/src/main/java/org/cyclops/integratedtunnels/part/aspect/TunnelAspectWriteBuilders.java
+++ b/src/main/java/org/cyclops/integratedtunnels/part/aspect/TunnelAspectWriteBuilders.java
@@ -134,7 +134,7 @@ public class TunnelAspectWriteBuilders {
                 if (partStateHolder.getState().getNetwork() != null) {
                     partType.addTargetToNetwork(
                             partStateHolder.getState().getNetwork(),
-                            partType.getEffectiveTargetPos(target, partState),
+                            target,
                             partStateHolder.getState().getPriority(),
                             partStateHolder.getState().getChannelInterface(),
                             partState


### PR DESCRIPTION
Closes #381

The bug is in Tunnels, not Dynamics.

## Problem

Interfaces register their target `PartPos` (block position **+ side**) in the positioned-addons network. Two things kept that registration out of sync with the part's target side override:

1. **The stale registration was never removed.** Saving the settings gui runs `ContainerPartSettings#onUpdate` → `setTargetSideOverride` (the state now holds the new side) → `network.setPriorityAndChannel(...)` → `PartTypeInterfacePositionedAddon#setPriorityAndChannel`, which does `removeTargetFromNetwork(target.getTarget())` followed by `addTargetToNetwork(target.getTarget())`. That `target` is recomputed from the *new* state, so the removal targeted the **new** position (which was not registered yet, making it a no-op) and the addition registered it. The **old** position, with the previous target side, stayed behind in `PositionedAddonsNetwork` (`removePosition` matches a `PartPos` exactly, side included).

   The target block was therefore exposed to the network on both the old and the new side at once, which is why the exporter in #381 could still reach the squeezer's input slot, while an importer (which resolves its target fresh on every tick) behaved correctly.

2. **The target passed to the part lifecycle methods is not always override-aware.** `PartNetworkElement#revalidate` calls `afterNetworkReAlive` with a raw `PartTarget.fromCenter(center)`, without the target side override and offset, so an interface re-registered on the default side after a chunk reload.

Two related gaps were found along the way:
* The wrench's `OFFSET_SIDE` mode calls `setTargetSideOverride` without any network re-registration, and `PartTypeInterfacePositionedAddonFiltering` was missing the `setTargetOffset` re-registration that its non-filtering sibling already had.
* `TunnelAspectWriteBuilders#propSetFilter` re-added the raw target position when a filter interface's filter changed.

## Changes

* `removeTargetFromNetwork` now removes the position that was effectively registered before (`state.getPos()`), falling back to the given position.
* A new `getEffectiveTargetPos(target, state)` derives the network position from the part state (`getTarget(center, state)`). It is used by all register/unregister/observe call sites in both interface part types and in the filter aspect, which also covers the revalidation path described above.
* `setTargetSideOverride` is now overridden in both interface part types to remove and re-add the interface, mirroring what `setTargetOffset` already did (and which the filtering variant now overrides as well). This needs the center position, so the interface state caches it via `getCenter`/`setCenter`, which are declared with no-op defaults on `IState` so that external implementors keep working.

## Testing

`./gradlew build` passes. This branch has no test sources, and game tests only exist for MC 1.21 and above, so the change is compile-verified plus code-path analysis rather than runtime-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8Jz1TvUoP9QwHFokseXXw

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8Jz1TvUoP9QwHFokseXXw)_