### PR TITLE
Improve tunnel performance in per-tick hot paths

### DIFF
--- a/src/main/java/org/cyclops/integratedtunnels/core/IngredientPredicateBlockOperator.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/IngredientPredicateBlockOperator.java
@@ -62,8 +62,8 @@ public class IngredientPredicateBlockOperator extends IngredientPredicate<ItemSt
     }
 
     @Override
-    public int hashCode() {
-        return super.hashCode()
+    protected int computeHashCode() {
+        return super.computeHashCode()
                 ^ this.predicate.hashCode()
                 ^ this.partTarget.hashCode();
     }

--- a/src/main/java/org/cyclops/integratedtunnels/core/ItemStorageBlockWrapper.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/ItemStorageBlockWrapper.java
@@ -155,9 +155,11 @@ public class ItemStorageBlockWrapper implements IIngredientComponentStorage<Item
     protected List<ItemStack> getItemStacks() {
         if (writeOnly) {
             if (!world.isEmptyBlock(pos)) {
-                boolean isDestReplaceable = world.getBlockState(pos).canBeReplaced(TunnelHelpers.createBlockItemUseContext(world, null, pos, side, hand));
-                if (!isDestReplaceable || !ignoreReplacable) {
-                    BlockState blockState = world.getBlockState(pos);
+                BlockState blockState = world.getBlockState(pos);
+                // Only determine replaceability when it can still influence the outcome,
+                // as constructing a block place context is relatively expensive.
+                if (!ignoreReplacable
+                        || !blockState.canBeReplaced(TunnelHelpers.createBlockItemUseContext(world, null, pos, side, hand))) {
                     return Lists.newArrayList(BlockHelpers.getItemStackFromBlockState(blockState));
                 }
             }

--- a/src/main/java/org/cyclops/integratedtunnels/core/TunnelFluidHelpers.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/TunnelFluidHelpers.java
@@ -139,11 +139,15 @@ public class TunnelFluidHelpers {
                                          IngredientPredicate<FluidStack, Integer> fluidStackMatcher, boolean blockUpdate,
                                          boolean ignoreReplacable, boolean craftIfFailed) throws EvaluationException {
         BlockState destBlockState = world.getBlockState(pos);
-        final boolean isDestNonSolid = !destBlockState.isSolid();
-        final boolean isDestReplaceable = destBlockState.canBeReplaced(TunnelHelpers.createBlockItemUseContext(world, null, pos, Direction.UP, InteractionHand.MAIN_HAND));
-        if (!world.isEmptyBlock(pos)
-                && (!isDestNonSolid || !(ignoreReplacable && isDestReplaceable) || destBlockState.liquid())) {
-            return null;
+        if (!world.isEmptyBlock(pos)) {
+            // Only determine replaceability when it can still influence the outcome,
+            // as constructing a block place context is relatively expensive.
+            if (destBlockState.isSolid()
+                    || destBlockState.liquid()
+                    || !ignoreReplacable
+                    || !destBlockState.canBeReplaced(TunnelHelpers.createBlockItemUseContext(world, null, pos, Direction.UP, InteractionHand.MAIN_HAND))) {
+                return null;
+            }
         }
 
         IIngredientComponentStorage<FluidStack, Integer> destination = new FluidStorageBlockWrapper((ServerLevel) world, pos, null, blockUpdate);

--- a/src/main/java/org/cyclops/integratedtunnels/core/TunnelItemHelpers.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/TunnelItemHelpers.java
@@ -162,11 +162,14 @@ public class TunnelItemHelpers {
                                        IngredientPredicate<ItemStack, Integer> itemStackMatcher, InteractionHand hand,
                                        boolean blockUpdate, boolean ignoreReplacable, boolean craftIfFailed) throws EvaluationException {
         BlockState destBlockState = world.getBlockState(pos);
-        final boolean isDestNonSolid = !destBlockState.isSolid();
-        final boolean isDestReplaceable = destBlockState.canBeReplaced(TunnelHelpers.createBlockItemUseContext(world, null, pos, side, hand));
-        if (!world.isEmptyBlock(pos)
-                && (!isDestNonSolid || !(ignoreReplacable && isDestReplaceable))) {
-            return null;
+        if (!world.isEmptyBlock(pos)) {
+            // Only determine replaceability when it can still influence the outcome,
+            // as constructing a block place context is relatively expensive.
+            if (destBlockState.isSolid()
+                    || !ignoreReplacable
+                    || !destBlockState.canBeReplaced(TunnelHelpers.createBlockItemUseContext(world, null, pos, side, hand))) {
+                return null;
+            }
         }
 
         IIngredientComponentStorage<ItemStack, Integer> destinationBlock = new ItemStorageBlockWrapper(
@@ -204,9 +207,11 @@ public class TunnelItemHelpers {
                                               boolean ignoreReplacable, int fortune, boolean silkTouch,
                                               boolean breakOnNoDrops, boolean matchBlock) throws EvaluationException {
         BlockState destBlockState = world.getBlockState(pos);
-        final boolean isDestReplaceable = destBlockState.canBeReplaced(TunnelHelpers.createBlockItemUseContext(world, null, pos, side, hand));
+        // Only determine replaceability when it can still influence the outcome,
+        // as constructing a block place context is relatively expensive.
         if (world.isEmptyBlock(pos)
-                || ((ignoreReplacable && isDestReplaceable) || destBlockState.liquid())) {
+                || destBlockState.liquid()
+                || (ignoreReplacable && destBlockState.canBeReplaced(TunnelHelpers.createBlockItemUseContext(world, null, pos, side, hand)))) {
             return null;
         }
 

--- a/src/main/java/org/cyclops/integratedtunnels/core/part/IPartTypeInterfacePositionedAddon.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/part/IPartTypeInterfacePositionedAddon.java
@@ -1,7 +1,13 @@
 package org.cyclops.integratedtunnels.core.part;
 
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.capabilities.BlockCapability;
+import net.neoforged.neoforge.capabilities.ICapabilityInvalidationListener;
 import org.apache.commons.lang3.tuple.Pair;
 import org.cyclops.cyclopscore.helper.BlockEntityHelpers;
 import org.cyclops.integrateddynamics.api.evaluate.variable.ValueDeseralizationContext;
@@ -54,6 +60,100 @@ public interface IPartTypeInterfacePositionedAddon<N extends IPositionedAddonsNe
      */
     public default PartPos getEffectiveTargetPos(PartTarget target, S state) {
         return getTarget(target.getCenter(), state).getTarget();
+    }
+
+    /**
+     * Check if a neighbour change at the given position can influence the target capability of this interface.
+     *
+     * Re-checking the target capability requires a block entity and a block capability lookup,
+     * while neighbour changes are very frequent: every comparator-relevant change of a nearby container
+     * triggers one on the cable, so an interface exposing a chest would re-check for every item that
+     * moves in or out of it. This method filters those out.
+     *
+     * A capability can appear or disappear without the block state changing at all,
+     * for example when the configuration of a block entity changes.
+     * NeoForge requires such changes to be signalled through
+     * {@link net.minecraft.world.level.Level#invalidateCapabilities(BlockPos)}, which is what
+     * {@link #registerTargetCapabilityListener(PartPos, IState)} subscribes to, so that they mark the
+     * target as needing a re-check here.
+     *
+     * @param state The part state.
+     * @param world The world the neighbour change happened in.
+     * @param neighbourBlockPos The position of the neighbour that was changed.
+     * @return If the target capability of this interface may have changed.
+     */
+    public default boolean canNeighbourChangeAffectTarget(S state, BlockGetter world, BlockPos neighbourBlockPos) {
+        PartPos pos = state.getPos();
+        PartPos center = state.getCenter();
+        if (pos == null || center == null || !state.isValidTargetCapability()) {
+            // If we don't know our exposed position yet, or don't expose a target capability yet,
+            // we have to assume that a target may have become available.
+            return true;
+        }
+
+        if (state.isTargetCapabilityInvalidated()) {
+            // Our target signalled that its capabilities changed since we last checked them.
+            return true;
+        }
+
+        BlockPos targetPos = pos.getPos().getBlockPos();
+        if (targetPos.equals(neighbourBlockPos)) {
+            // By far the most neighbour changes we receive are the comparator updates that our own target
+            // emits whenever its contents change, which can not affect its capabilities.
+            // A block state change at our target can, and while it is supposed to be accompanied by a
+            // capability invalidation, not all blocks do so, so fall back to comparing block states here.
+            BlockState validatedBlockState = state.getValidatedTargetBlockState();
+            return validatedBlockState == null || world.getBlockState(neighbourBlockPos) != validatedBlockState;
+        }
+
+        // Interfaces with a target offset are not necessarily a neighbour of their target,
+        // so they may never receive a neighbour change for it, and have to keep re-checking.
+        Direction side = center.getSide();
+        BlockPos centerPos = center.getPos().getBlockPos();
+        return targetPos.getX() != centerPos.getX() + side.getStepX()
+                || targetPos.getY() != centerPos.getY() + side.getStepY()
+                || targetPos.getZ() != centerPos.getZ() + side.getStepZ();
+    }
+
+    /**
+     * Remember that the target capability at the given position was just checked,
+     * so that {@link #canNeighbourChangeAffectTarget(IState, BlockGetter, BlockPos)} can tell
+     * a change of that capability apart from a mere contents change of the target.
+     * @param posTarget The position that this interface exposes to the network.
+     * @param state The part state.
+     */
+    public default void rememberValidatedTarget(PartPos posTarget, S state) {
+        Level level = posTarget.getPos().getLevel(true);
+        state.setValidatedTargetBlockState(level == null ? null : level.getBlockState(posTarget.getPos().getBlockPos()));
+        state.setTargetCapabilityInvalidated(false);
+        registerTargetCapabilityListener(posTarget, state);
+    }
+
+    /**
+     * Subscribe to capability invalidations at the given target position, if not subscribed already.
+     *
+     * This is the only reliable signal for capabilities that appear or disappear without the block state
+     * changing, such as when the configuration of a block entity changes.
+     * NeoForge holds these listeners weakly, so the part state keeps the only strong reference to it.
+     *
+     * @param posTarget The position that this interface exposes to the network.
+     * @param state The part state.
+     */
+    public default void registerTargetCapabilityListener(PartPos posTarget, S state) {
+        BlockPos blockPos = posTarget.getPos().getBlockPos();
+        if (blockPos.equals(state.getTargetCapabilityListenerPos())) {
+            // We are already listening at this position.
+            return;
+        }
+        if (posTarget.getPos().getLevel(true) instanceof ServerLevel serverLevel) {
+            ICapabilityInvalidationListener listener = () -> {
+                state.setTargetCapabilityInvalidated(true);
+                return true;
+            };
+            // The part state must hold on to the listener, as NeoForge only references it weakly.
+            state.setTargetCapabilityListener(blockPos, listener);
+            serverLevel.registerCapabilityListener(blockPos, listener);
+        }
     }
 
     public default void scheduleNetworkObservation(PartTarget target, S state) {
@@ -117,6 +217,7 @@ public interface IPartTypeInterfacePositionedAddon<N extends IPositionedAddonsNe
             state.setPos(posTarget);
             state.setCenter(target.getCenter());
             state.setValidTargetCapability(validTargetCapability);
+            rememberValidatedTarget(posTarget, state);
             if (validTargetCapability) {
                 onAddingPositionToNetwork(networkCapability, network, posTarget, priority, channelInterface, state);
             }
@@ -144,6 +245,8 @@ public interface IPartTypeInterfacePositionedAddon<N extends IPositionedAddonsNe
         state.setNetworks(null, null, null);
         state.setPos(null);
         state.setValidTargetCapability(false);
+        state.setValidatedTargetBlockState(null);
+        state.setTargetCapabilityInvalidated(true);
     }
 
     /**
@@ -167,7 +270,8 @@ public interface IPartTypeInterfacePositionedAddon<N extends IPositionedAddonsNe
 
     public default void updateTargetInNetwork(INetwork network, PartTarget target, int priority, int channelInterface, S state) {
         if (network.getCapability(getNetworkCapability()).isPresent()) {
-            boolean validTargetCapability = getTargetCapabilityInstance(getEffectiveTargetPos(target, state))
+            PartPos posTarget = getEffectiveTargetPos(target, state);
+            boolean validTargetCapability = getTargetCapabilityInstance(posTarget)
                     .map(this::isTargetCapabilityValid)
                     .orElse(false);
             boolean wasValidTargetCapability = state.isValidTargetCapability();
@@ -175,6 +279,8 @@ public interface IPartTypeInterfacePositionedAddon<N extends IPositionedAddonsNe
             if (validTargetCapability != wasValidTargetCapability) {
                 removeTargetFromNetwork(network, state);
                 addTargetToNetwork(network, target, priority, channelInterface, state);
+            } else {
+                rememberValidatedTarget(posTarget, state);
             }
         }
     }
@@ -205,6 +311,65 @@ public interface IPartTypeInterfacePositionedAddon<N extends IPositionedAddonsNe
          */
         // TODO: make a non-default method in next major
         public default void setCenter(@Nullable PartPos center) {
+
+        }
+
+        /**
+         * @return The block state that was present at the exposed target position when its capability
+         *         was last checked, or null if it is unknown.
+         */
+        // TODO: make a non-default method in next major
+        @Nullable
+        public default BlockState getValidatedTargetBlockState() {
+            return null;
+        }
+
+        /**
+         * Set the block state that is present at the exposed target position.
+         * @param blockState The block state, or null if it is unknown.
+         */
+        // TODO: make a non-default method in next major
+        public default void setValidatedTargetBlockState(@Nullable BlockState blockState) {
+
+        }
+
+        /**
+         * @return If the capabilities at the exposed target position were invalidated
+         *         since they were last checked.
+         */
+        // TODO: make a non-default method in next major
+        public default boolean isTargetCapabilityInvalidated() {
+            return true;
+        }
+
+        /**
+         * Set if the capabilities at the exposed target position were invalidated
+         * since they were last checked.
+         * @param invalidated If they were invalidated.
+         */
+        // TODO: make a non-default method in next major
+        public default void setTargetCapabilityInvalidated(boolean invalidated) {
+
+        }
+
+        /**
+         * @return The position that this state is listening for capability invalidations at,
+         *         or null if it is not listening anywhere.
+         */
+        // TODO: make a non-default method in next major
+        @Nullable
+        public default BlockPos getTargetCapabilityListenerPos() {
+            return null;
+        }
+
+        /**
+         * Store the capability invalidation listener for the given position.
+         * The state must keep a strong reference to it, as NeoForge only references it weakly.
+         * @param pos The position that is being listened at.
+         * @param listener The listener.
+         */
+        // TODO: make a non-default method in next major
+        public default void setTargetCapabilityListener(BlockPos pos, ICapabilityInvalidationListener listener) {
 
         }
 

--- a/src/main/java/org/cyclops/integratedtunnels/core/part/PartTypeInterfacePositionedAddon.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/part/PartTypeInterfacePositionedAddon.java
@@ -15,6 +15,8 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.neoforge.capabilities.ICapabilityInvalidationListener;
 import org.apache.commons.lang3.tuple.Triple;
 import org.cyclops.cyclopscore.datastructure.DimPos;
 import org.cyclops.cyclopscore.network.PacketCodec;
@@ -118,7 +120,7 @@ public abstract class PartTypeInterfacePositionedAddon<N extends IPositionedAddo
     @Override
     public void onBlockNeighborChange(INetwork network, IPartNetwork partNetwork, PartTarget target, S state, BlockGetter world, Block neighbourBlock, BlockPos neighbourBlockPos) {
         super.onBlockNeighborChange(network, partNetwork, target, state, world, neighbourBlock, neighbourBlockPos);
-        if (network != null) {
+        if (network != null && canNeighbourChangeAffectTarget(state, world, neighbourBlockPos)) {
             updateTargetInNetwork(network, target, state.getPriority(), state.getChannelInterface(), state);
         }
     }
@@ -189,6 +191,11 @@ public abstract class PartTypeInterfacePositionedAddon<N extends IPositionedAddo
         private N positionedAddonsNetwork = null;
         private PartPos pos = null;
         private PartPos center = null;
+        private BlockState validatedTargetBlockState = null;
+        private boolean targetCapabilityInvalidated = true;
+        private BlockPos targetCapabilityListenerPos = null;
+        // Strong reference: NeoForge only holds capability invalidation listeners weakly.
+        private ICapabilityInvalidationListener targetCapabilityListener = null;
         private boolean validTargetCapability = false;
         private int channelInterface = 0;
 
@@ -260,6 +267,39 @@ public abstract class PartTypeInterfacePositionedAddon<N extends IPositionedAddo
         @Override
         public void setCenter(@Nullable PartPos center) {
             this.center = center;
+        }
+
+        @Nullable
+        @Override
+        public BlockState getValidatedTargetBlockState() {
+            return validatedTargetBlockState;
+        }
+
+        @Override
+        public void setValidatedTargetBlockState(@Nullable BlockState validatedTargetBlockState) {
+            this.validatedTargetBlockState = validatedTargetBlockState;
+        }
+
+        @Override
+        public boolean isTargetCapabilityInvalidated() {
+            return targetCapabilityInvalidated;
+        }
+
+        @Override
+        public void setTargetCapabilityInvalidated(boolean targetCapabilityInvalidated) {
+            this.targetCapabilityInvalidated = targetCapabilityInvalidated;
+        }
+
+        @Nullable
+        @Override
+        public BlockPos getTargetCapabilityListenerPos() {
+            return targetCapabilityListenerPos;
+        }
+
+        @Override
+        public void setTargetCapabilityListener(BlockPos pos, ICapabilityInvalidationListener listener) {
+            this.targetCapabilityListenerPos = pos;
+            this.targetCapabilityListener = listener;
         }
 
         @Override

--- a/src/main/java/org/cyclops/integratedtunnels/core/part/PartTypeInterfacePositionedAddonFiltering.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/part/PartTypeInterfacePositionedAddonFiltering.java
@@ -13,6 +13,8 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.neoforge.capabilities.ICapabilityInvalidationListener;
 import org.apache.commons.lang3.tuple.Triple;
 import org.cyclops.integrateddynamics.api.evaluate.variable.ValueDeseralizationContext;
 import org.cyclops.integrateddynamics.api.network.INetwork;
@@ -123,7 +125,7 @@ public abstract class PartTypeInterfacePositionedAddonFiltering<N extends IPosit
     @Override
     public void onBlockNeighborChange(INetwork network, IPartNetwork partNetwork, PartTarget target, S state, BlockGetter world, Block neighbourBlock, BlockPos neighbourBlockPos) {
         super.onBlockNeighborChange(network, partNetwork, target, state, world, neighbourBlock, neighbourBlockPos);
-        if (network != null) {
+        if (network != null && canNeighbourChangeAffectTarget(state, world, neighbourBlockPos)) {
             updateTargetInNetwork(network, target, state.getPriority(), state.getChannelInterface(), state);
         }
     }
@@ -179,6 +181,11 @@ public abstract class PartTypeInterfacePositionedAddonFiltering<N extends IPosit
         private N positionedAddonsNetwork = null;
         private PartPos pos = null;
         private PartPos center = null;
+        private BlockState validatedTargetBlockState = null;
+        private boolean targetCapabilityInvalidated = true;
+        private BlockPos targetCapabilityListenerPos = null;
+        // Strong reference: NeoForge only holds capability invalidation listeners weakly.
+        private ICapabilityInvalidationListener targetCapabilityListener = null;
         private boolean validTargetCapability = false;
         private int channelInterface = 0;
 
@@ -262,6 +269,39 @@ public abstract class PartTypeInterfacePositionedAddonFiltering<N extends IPosit
         @Override
         public void setCenter(@Nullable PartPos center) {
             this.center = center;
+        }
+
+        @Nullable
+        @Override
+        public BlockState getValidatedTargetBlockState() {
+            return validatedTargetBlockState;
+        }
+
+        @Override
+        public void setValidatedTargetBlockState(@Nullable BlockState validatedTargetBlockState) {
+            this.validatedTargetBlockState = validatedTargetBlockState;
+        }
+
+        @Override
+        public boolean isTargetCapabilityInvalidated() {
+            return targetCapabilityInvalidated;
+        }
+
+        @Override
+        public void setTargetCapabilityInvalidated(boolean targetCapabilityInvalidated) {
+            this.targetCapabilityInvalidated = targetCapabilityInvalidated;
+        }
+
+        @Nullable
+        @Override
+        public BlockPos getTargetCapabilityListenerPos() {
+            return targetCapabilityListenerPos;
+        }
+
+        @Override
+        public void setTargetCapabilityListener(BlockPos pos, ICapabilityInvalidationListener listener) {
+            this.targetCapabilityListenerPos = pos;
+            this.targetCapabilityListener = listener;
         }
 
         public boolean isRequireAspectUpdateAndReset() {

--- a/src/main/java/org/cyclops/integratedtunnels/core/predicate/IngredientPredicate.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/predicate/IngredientPredicate.java
@@ -1,16 +1,14 @@
 package org.cyclops.integratedtunnels.core.predicate;
 
-import com.google.common.collect.Lists;
 import org.cyclops.commoncapabilities.api.ingredient.IIngredientMatcher;
 import org.cyclops.commoncapabilities.api.ingredient.IngredientComponent;
 import org.cyclops.integratedtunnels.part.aspect.ITunnelTransfer;
 
 import javax.annotation.Nonnull;
-import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.Objects;
 import java.util.function.Predicate;
-import java.util.stream.StreamSupport;
 
 /**
  * A predicate for matching ingredient components.
@@ -27,6 +25,15 @@ public abstract class IngredientPredicate<T, M> implements Predicate<T>, ITunnel
     private final boolean empty;
     private final int maxQuantity;
     private final boolean exactQuantity;
+
+    /**
+     * Lazily computed value of {@link #hashCode()}.
+     * Predicates are immutable, but are constructed anew on every aspect evaluation,
+     * while their hash is needed on every transfer for the transfer cache lookup,
+     * so it pays off to only compute it once.
+     * A value of 0 means 'not computed yet'.
+     */
+    private int hashCodeCached = 0;
 
     public IngredientPredicate(IngredientComponent<T, M> ingredientComponent,
                                Iterable<T> instances, M matchFlags, boolean blacklist, boolean empty,
@@ -88,6 +95,9 @@ public abstract class IngredientPredicate<T, M> implements Predicate<T>, ITunnel
 
     @Override
     public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
         if (!(obj instanceof IngredientPredicate)) {
             return false;
         }
@@ -102,27 +112,49 @@ public abstract class IngredientPredicate<T, M> implements Predicate<T>, ITunnel
             return false;
         }
 
-        ArrayList<T> instances1 = Lists.newArrayList(this.instances);
-        ArrayList<T> instances2 = Lists.newArrayList(that.instances);
-        if (instances1.size() != instances2.size()) {
-            return false;
-        }
+        // Compare both instance iterables in lock-step, so that no intermediate collections are needed.
         IIngredientMatcher<T, M> matcher = this.ingredientComponent.getMatcher();
-        for (int i = 0; i < instances1.size(); i++) {
-            if (!matcher.matchesExactly(instances1.get(i), instances2.get(i))) {
+        Iterator<T> it1 = this.instances.iterator();
+        Iterator<T> it2 = ((IngredientPredicate<T, M>) that).instances.iterator();
+        while (it1.hasNext() && it2.hasNext()) {
+            if (!matcher.matchesExactly(it1.next(), it2.next())) {
                 return false;
             }
         }
 
-        return true;
+        return !it1.hasNext() && !it2.hasNext();
     }
 
     @Override
     public int hashCode() {
+        int hash = this.hashCodeCached;
+        if (hash == 0) {
+            hash = computeHashCode();
+            if (hash == 0) {
+                // Reserve 0 for 'not computed yet'
+                hash = 1;
+            }
+            this.hashCodeCached = hash;
+        }
+        return hash;
+    }
+
+    /**
+     * Calculate the hash code of this predicate.
+     *
+     * The result of this method is cached by {@link #hashCode()},
+     * so subclasses must override this method instead of {@link #hashCode()}.
+     *
+     * @return The hash code.
+     */
+    protected int computeHashCode() {
+        IIngredientMatcher<T, M> matcher = ingredientComponent.getMatcher();
+        int instancesHash = 0;
+        for (T instance : instances) {
+            instancesHash = instancesHash ^ matcher.hash(instance);
+        }
         return ingredientComponent.hashCode()
-                ^ StreamSupport.stream(instances.spliterator(), false)
-                    .map(instance -> ingredientComponent.getMatcher().hash(instance))
-                    .reduce(0, (a, b) -> a ^ b)
+                ^ instancesHash
                 ^ Objects.hashCode(matchFlags)
                 ^ (blacklist ? 1 : 0)
                 ^ (empty ? 2 : 4)

--- a/src/main/java/org/cyclops/integratedtunnels/core/predicate/IngredientPredicateBlockList.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/predicate/IngredientPredicateBlockList.java
@@ -59,8 +59,8 @@ public class IngredientPredicateBlockList extends IngredientPredicate<ItemStack,
     }
 
     @Override
-    public int hashCode() {
-        return super.hashCode()
+    protected int computeHashCode() {
+        return super.computeHashCode()
                 ^ (this.blacklist ? 1 : 0) << 1
                 ^ (this.checkItem ? 1 : 0) << 2
                 ^ (this.checkStackSize ? 1 : 0) << 3

--- a/src/main/java/org/cyclops/integratedtunnels/core/predicate/IngredientPredicateFluidStackList.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/predicate/IngredientPredicateFluidStackList.java
@@ -57,8 +57,8 @@ public class IngredientPredicateFluidStackList extends IngredientPredicate<Fluid
     }
 
     @Override
-    public int hashCode() {
-        return super.hashCode()
+    protected int computeHashCode() {
+        return super.computeHashCode()
                 ^ (this.blacklist ? 1 : 0) << 1
                 ^ (this.checkFluid ? 1 : 0) << 2
                 ^ (this.checkAmount ? 1 : 0) << 3

--- a/src/main/java/org/cyclops/integratedtunnels/core/predicate/IngredientPredicateFluidStackNbt.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/predicate/IngredientPredicateFluidStackNbt.java
@@ -63,8 +63,8 @@ public class IngredientPredicateFluidStackNbt extends IngredientPredicate<FluidS
     }
 
     @Override
-    public int hashCode() {
-        return super.hashCode()
+    protected int computeHashCode() {
+        return super.computeHashCode()
                 ^ (this.blacklist ? 1 : 0) << 1
                 ^ (this.requireNbt ? 1 : 0) << 2
                 ^ (this.subset ? 1 : 0) << 3

--- a/src/main/java/org/cyclops/integratedtunnels/core/predicate/IngredientPredicateFluidStackOperator.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/predicate/IngredientPredicateFluidStackOperator.java
@@ -58,8 +58,8 @@ public class IngredientPredicateFluidStackOperator extends IngredientPredicate<F
     }
 
     @Override
-    public int hashCode() {
-        return super.hashCode()
+    protected int computeHashCode() {
+        return super.computeHashCode()
                 ^ this.predicate.hashCode()
                 ^ this.partTarget.hashCode();
     }

--- a/src/main/java/org/cyclops/integratedtunnels/core/predicate/IngredientPredicateItemStackList.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/predicate/IngredientPredicateItemStackList.java
@@ -57,8 +57,8 @@ public class IngredientPredicateItemStackList extends IngredientPredicate<ItemSt
     }
 
     @Override
-    public int hashCode() {
-        return super.hashCode()
+    protected int computeHashCode() {
+        return super.computeHashCode()
                 ^ (this.blacklist ? 1 : 0) << 1
                 ^ (this.checkItem ? 1 : 0) << 2
                 ^ (this.checkStackSize ? 1 : 0) << 3

--- a/src/main/java/org/cyclops/integratedtunnels/core/predicate/IngredientPredicateItemStackNbt.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/predicate/IngredientPredicateItemStackNbt.java
@@ -63,8 +63,8 @@ public class IngredientPredicateItemStackNbt extends IngredientPredicate<ItemSta
     }
 
     @Override
-    public int hashCode() {
-        return super.hashCode()
+    protected int computeHashCode() {
+        return super.computeHashCode()
                 ^ (this.blacklist ? 1 : 0) << 1
                 ^ (this.requireNbt ? 1 : 0) << 2
                 ^ (this.subset ? 1 : 0) << 3

--- a/src/main/java/org/cyclops/integratedtunnels/core/predicate/IngredientPredicateItemStackOperator.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/predicate/IngredientPredicateItemStackOperator.java
@@ -58,8 +58,8 @@ public class IngredientPredicateItemStackOperator extends IngredientPredicate<It
     }
 
     @Override
-    public int hashCode() {
-        return super.hashCode()
+    protected int computeHashCode() {
+        return super.computeHashCode()
                 ^ this.predicate.hashCode()
                 ^ this.partTarget.hashCode();
     }

--- a/src/main/java/org/cyclops/integratedtunnels/gametest/GameTestsItems.java
+++ b/src/main/java/org/cyclops/integratedtunnels/gametest/GameTestsItems.java
@@ -14,6 +14,7 @@ import net.minecraft.world.level.block.HopperBlock;
 import net.minecraft.world.level.block.entity.ChestBlockEntity;
 import net.minecraft.world.level.block.entity.FurnaceBlockEntity;
 import net.minecraft.world.level.block.entity.HopperBlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.gametest.GameTestHolder;
 import net.neoforged.neoforge.gametest.PrefixGameTestTemplate;
 import org.cyclops.cyclopscore.datastructure.DimPos;
@@ -32,6 +33,7 @@ import org.cyclops.integrateddynamics.core.helper.NetworkHelpers;
 import org.cyclops.integrateddynamics.core.helper.PartHelpers;
 import org.cyclops.integrateddynamics.part.aspect.Aspects;
 import org.cyclops.integratedtunnels.Reference;
+import org.cyclops.integratedtunnels.core.part.IPartTypeInterfacePositionedAddon;
 import org.cyclops.integratedtunnels.part.PartTypeInterfaceFilteringItem;
 import org.cyclops.integratedtunnels.part.PartTypes;
 import org.cyclops.integratedtunnels.part.aspect.TunnelAspectWriteBuilders;
@@ -1100,6 +1102,123 @@ public class GameTestsItems {
                 .thenIdle(TICKS_TRANSFER)
                 .thenExecute(() -> assertInterfaceTargetSideExported(helper))
                 .thenSucceed();
+    }
+
+    /**
+     * An interface must pick up a container that is only placed after the interface joined the network.
+     */
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = TIMEOUT)
+    public void testItemsInterfaceTargetPlacedLater(GameTestHelper helper) {
+        // Place cable
+        helper.setBlock(POS, RegistryEntries.BLOCK_CABLE.value());
+        helper.setBlock(POS.east(), RegistryEntries.BLOCK_CABLE.value());
+
+        // Place item interface, without a container to expose yet
+        PartHelpers.addPart(helper.getLevel(), helper.absolutePos(POS), Direction.WEST, PartTypes.INTERFACE_ITEM, new ItemStack(PartTypes.INTERFACE_ITEM.getItem()));
+        PartPos posInterface = PartPos.of(helper.getLevel(), helper.absolutePos(POS), Direction.WEST);
+
+        // Place item exporter with an output chest, but don't activate it yet
+        PartHelpers.addPart(helper.getLevel(), helper.absolutePos(POS.east()), Direction.EAST, PartTypes.EXPORTER_ITEM, new ItemStack(PartTypes.EXPORTER_ITEM.getItem()));
+        helper.setBlock(POS.east().east(), Blocks.CHEST);
+
+        helper.startSequence()
+                // Let the interface join the network without a container
+                .thenIdle(TICKS_NETWORK_INIT)
+                .thenExecute(() -> helper.assertFalse(isInterfaceTargetValid(posInterface), "Interface exposed a container before one was placed"))
+                .thenExecute(() -> {
+                    // Only now place the container that the interface should expose
+                    helper.setBlock(POS.west(), Blocks.CHEST);
+                    ChestBlockEntity chestIn = helper.getBlockEntity(POS.west());
+                    chestIn.setItem(0, new ItemStack(Items.WHITE_WOOL));
+                })
+                .thenIdle(TICKS_NETWORK_INIT)
+                .thenExecute(() -> helper.assertTrue(isInterfaceTargetValid(posInterface), "Interface did not expose the container that was placed later"))
+                // Only start exporting once the container is part of the network.
+                // An exporter that runs on an empty network first would fall asleep,
+                // and that sleep expires on wall-clock time rather than on ticks.
+                .thenExecute(() -> placeVariableInWriter(helper.getLevel(), PartPos.of(helper.getLevel(), helper.absolutePos(POS.east()), Direction.EAST),
+                        TunnelAspects.Write.Item.BOOLEAN_EXPORT, new ItemStack(RegistryEntries.ITEM_VARIABLE)))
+                .thenIdle(TICKS_TRANSFER)
+                .thenExecute(() -> {
+                    helper.assertContainerContains(POS.east().east(), Items.WHITE_WOOL);
+                    helper.assertContainerEmpty(POS.west());
+                })
+                .thenSucceed();
+    }
+
+    /**
+     * An interface must stop exposing its container once that container is removed from the world.
+     */
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = TIMEOUT)
+    public void testItemsInterfaceTargetRemovedLater(GameTestHelper helper) {
+        // Place cable
+        helper.setBlock(POS, RegistryEntries.BLOCK_CABLE.value());
+
+        // Place item interface with a container to expose
+        PartHelpers.addPart(helper.getLevel(), helper.absolutePos(POS), Direction.WEST, PartTypes.INTERFACE_ITEM, new ItemStack(PartTypes.INTERFACE_ITEM.getItem()));
+        helper.setBlock(POS.west(), Blocks.CHEST);
+        PartPos posInterface = PartPos.of(helper.getLevel(), helper.absolutePos(POS), Direction.WEST);
+
+        helper.startSequence()
+                // Let the interface join the network with its container
+                .thenIdle(TICKS_NETWORK_INIT)
+                .thenExecute(() -> helper.assertTrue(isInterfaceTargetValid(posInterface), "Interface did not expose its container"))
+                .thenExecute(() -> helper.setBlock(POS.west(), Blocks.AIR))
+                .thenIdle(TICKS_NETWORK_INIT)
+                .thenExecute(() -> helper.assertFalse(isInterfaceTargetValid(posInterface), "Interface still exposes its removed container"))
+                .thenSucceed();
+    }
+
+    /**
+     * A capability can appear or disappear at the target position without its block state changing at all,
+     * for example when the configuration of a block entity changes.
+     * NeoForge requires such changes to be signalled through {@link net.minecraft.world.level.Level#invalidateCapabilities(BlockPos)},
+     * so the interface must subscribe to those invalidations and re-check its target on the next neighbour change.
+     */
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = TIMEOUT)
+    public void testItemsInterfaceTargetCapabilityInvalidated(GameTestHelper helper) {
+        // Place cable
+        helper.setBlock(POS, RegistryEntries.BLOCK_CABLE.value());
+
+        // Place item interface with a container to expose
+        PartHelpers.addPart(helper.getLevel(), helper.absolutePos(POS), Direction.WEST, PartTypes.INTERFACE_ITEM, new ItemStack(PartTypes.INTERFACE_ITEM.getItem()));
+        helper.setBlock(POS.west(), Blocks.CHEST);
+        PartPos posInterface = PartPos.of(helper.getLevel(), helper.absolutePos(POS), Direction.WEST);
+
+        helper.startSequence()
+                // Let the interface join the network with its container
+                .thenIdle(TICKS_NETWORK_INIT)
+                .thenExecute(() -> {
+                    helper.assertTrue(isInterfaceTargetValid(posInterface), "Interface did not expose its container");
+                    helper.assertFalse(isInterfaceTargetCapabilityInvalidated(posInterface), "Interface did not validate its target capability");
+                })
+                .thenExecute(() -> {
+                    // Signal that the capabilities at the target changed, without touching its block state
+                    BlockState blockStateBefore = helper.getLevel().getBlockState(helper.absolutePos(POS.west()));
+                    helper.getLevel().invalidateCapabilities(helper.absolutePos(POS.west()));
+                    helper.assertValueEqual(helper.getLevel().getBlockState(helper.absolutePos(POS.west())), blockStateBefore,
+                            "Block state at the target changed");
+
+                    helper.assertTrue(isInterfaceTargetCapabilityInvalidated(posInterface), "Interface did not observe the invalidation of its target capability");
+                })
+                // Trigger a neighbour change that is unrelated to the target
+                .thenExecute(() -> helper.setBlock(POS.above(), Blocks.STONE))
+                .thenIdle(TICKS_NETWORK_INIT)
+                .thenExecute(() -> {
+                    helper.assertFalse(isInterfaceTargetCapabilityInvalidated(posInterface), "Interface did not re-check its invalidated target capability");
+                    helper.assertTrue(isInterfaceTargetValid(posInterface), "Interface stopped exposing its unchanged container");
+                })
+                .thenSucceed();
+    }
+
+    protected static boolean isInterfaceTargetValid(PartPos posInterface) {
+        return ((IPartTypeInterfacePositionedAddon.IState<?, ?, ?, ?>) PartHelpers.getPart(posInterface).getState())
+                .isValidTargetCapability();
+    }
+
+    protected static boolean isInterfaceTargetCapabilityInvalidated(PartPos posInterface) {
+        return ((IPartTypeInterfacePositionedAddon.IState<?, ?, ?, ?>) PartHelpers.getPart(posInterface).getState())
+                .isTargetCapabilityInvalidated();
     }
 
     /**


### PR DESCRIPTION
Three optimizations in the hottest Integrated Tunnels code paths, found by profiling the
`runGameTestServer` performance benchmarks with JFR (`settings=profile`) and attributing the
execution samples to this mod's own frames.

## 1. Don't re-check an interface's target capability on every neighbour change

Every content change of a container emits a comparator update, which makes
`BlockCable#onNeighborChange` fire and Integrated Dynamics dispatch `onBlockNeighborChange` to
every part on the neighbouring cables. `PartTypeInterfacePositionedAddon` and
`PartTypeInterfacePositionedAddonFiltering` responded to *every* such call with a full
`updateTargetInNetwork`: a network capability lookup, a recomputation of the effective target
position (`PartTarget#fromCenter` → `DimPos#getLevelKey`) and a block entity + block capability
lookup — only to conclude that the presence of the target capability had not changed.

For an interface watching a chest, that means the whole check ran again for every single item
that moved in or out of that chest.

Capabilities can only appear or disappear at the exposed position, so neighbour changes at other
positions are now skipped, except for interfaces that do not (yet) expose a capability (a target
may still become available) and interfaces whose target is not adjacent to them because of a
target offset (they may never receive a neighbour change for their target at all).

For neighbour changes at the exposed position itself, the interface subscribes to capability
invalidations there through `ServerLevel#registerCapabilityListener` and only re-checks once one
has come in since the last check. That covers capabilities that appear or disappear without a
block state change, which NeoForge requires to be signalled through
`Level#invalidateCapabilities(BlockPos)`. As a safety net for blocks that change their block state
without invalidating, the block state that was last validated is remembered and compared against
as well.

## 2. Cache `IngredientPredicate` hash codes and drop the allocations from `equals`

Every transfer looks up its connection in `TunnelHelpers#CACHE_INV_CHECKS`, which hashes the
`IngredientPredicate` that is part of the connection key. `hashCode()` built a `StreamSupport`
pipeline with boxed intermediate values on every call, and `equals()` copied both instance
iterables into `ArrayList`s. Both ran per part per tick.

`hashCode()` is now computed once per predicate (they are immutable, but constructed anew on
every aspect evaluation) through a new `computeHashCode()` that subclasses override, and
`equals()` compares the two iterables in lock-step without intermediate collections.

## 3. Only determine block replaceability when it can change the outcome

`TunnelItemHelpers#placeItems`/`#pickUpItems`, `TunnelFluidHelpers#placeFluids` and
`ItemStorageBlockWrapper#getItemStacks` eagerly called `BlockState#canBeReplaced` with a freshly
constructed `BlockPlaceContext` (plus a `BlockHitResult` and a `Vec3`), even when the surrounding
condition could never use the result — which is the case on every tick of a world block or fluid
exporter or importer with the default `ignoreReplacable = false`. These are now only evaluated
when they can still influence the result.

## Effect

Profile of a full benchmark run, counting execution samples on the server thread whose stack
contains an Integrated Tunnels frame:

| | before | after |
| --- | --- | --- |
| samples in Integrated Tunnels code | 297 / 18561 (1.60%) | 182 / 20733 (0.88%) |
| of which `updateTargetInNetwork` | 78 (26% of the mod's samples) | 0 |

Benchmark presets, comparing two runs under the same profiler settings (`avgNetworkTickTime`,
lower is better):

| preset | before | after |
| --- | --- | --- |
| `items_transfer` | 144.51 | 137.41 |
| `items_filtering_interfaces` | 150.63 | 138.42 |
| `items_transfer_predicate` | 137.88 | 130.64 |
| `items_index_query` | 64.33 | 60.21 |

Note that these benchmarks are noisy on shared hardware (the same preset varied by up to 40%
between unmodified runs), so the profile above is the more reliable signal of what changed.

For context: even before these changes, Integrated Tunnels' own code accounted for only ~1.6% of
server-thread samples in the heaviest preset. The bulk of the benchmark cost sits outside this
repository — mostly in Integrated Dynamics' per-neighbour-change network element recreation and
per-tick ingredient cache invalidation, and in `DimPos#getLevelKey`'s string-keyed cache lookups.

## Tests

Three game tests were added for the behaviour that (1) depends on:
`testItemsInterfaceTargetPlacedLater` (an interface must pick up a container that is placed after
it joined the network), `testItemsInterfaceTargetRemovedLater` (an interface must stop exposing
a container that is removed from the world), and
`testItemsInterfaceTargetCapabilityInvalidated` (an interface must re-check its target after a
capability invalidation that leaves the block state untouched).

`./gradlew build` and `./gradlew runGameTestServer` both pass.