### PR TITLE
Fix server crash when a filtered interface ticks while detached from its network

### DIFF
--- a/src/main/java/org/cyclops/integratedtunnels/core/part/PartTypeInterfacePositionedAddonFiltering.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/part/PartTypeInterfacePositionedAddonFiltering.java
@@ -16,7 +16,6 @@ import net.minecraft.world.level.block.Block;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.util.LazyOptional;
 import org.apache.commons.lang3.tuple.Triple;
-import org.cyclops.integrateddynamics.api.evaluate.variable.IVariable;
 import org.cyclops.integrateddynamics.api.evaluate.variable.ValueDeseralizationContext;
 import org.cyclops.integrateddynamics.api.network.INetwork;
 import org.cyclops.integrateddynamics.api.network.IPartNetwork;
@@ -275,20 +274,12 @@ public abstract class PartTypeInterfacePositionedAddonFiltering<N extends IPosit
         public void setTargetFilter(@Nullable PositionedAddonsNetworkIngredientsFilter<T> targetFilter) {
             this.targetFilter = targetFilter;
 
-            // Trigger aspect re-execution if needed
-            if (targetFilter == null) {
-                this.requireAspectUpdate();
-            } else if (this.network == null || this.partNetwork == null) {
-                // Our networks are unset while this part is detached from its network,
-                // which happens in-between a chunk unload and the corresponding network element revalidation.
-                // In that case, we can not resolve our variable yet,
-                // so we schedule another aspect update, which retries this once the networks are set again.
+            // Trigger aspect re-execution if needed.
+            // Our networks are unset while this part is detached from its network, in which case we retry later.
+            if (targetFilter == null || network == null || partNetwork == null) {
                 this.requireAspectUpdate();
             } else {
-                IVariable<?> variable = getVariable(this.network, this.partNetwork, this.valueDeseralizationContext);
-                if (variable != null) {
-                    variable.addInvalidationListener(this::requireAspectUpdate);
-                }
+                getVariable(network, partNetwork, valueDeseralizationContext).addInvalidationListener(this::requireAspectUpdate);
             }
         }
 

--- a/src/main/java/org/cyclops/integratedtunnels/core/part/PartTypeInterfacePositionedAddonFiltering.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/part/PartTypeInterfacePositionedAddonFiltering.java
@@ -16,6 +16,7 @@ import net.minecraft.world.level.block.Block;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.util.LazyOptional;
 import org.apache.commons.lang3.tuple.Triple;
+import org.cyclops.integrateddynamics.api.evaluate.variable.IVariable;
 import org.cyclops.integrateddynamics.api.evaluate.variable.ValueDeseralizationContext;
 import org.cyclops.integrateddynamics.api.network.INetwork;
 import org.cyclops.integrateddynamics.api.network.IPartNetwork;
@@ -277,8 +278,17 @@ public abstract class PartTypeInterfacePositionedAddonFiltering<N extends IPosit
             // Trigger aspect re-execution if needed
             if (targetFilter == null) {
                 this.requireAspectUpdate();
+            } else if (this.network == null || this.partNetwork == null) {
+                // Our networks are unset while this part is detached from its network,
+                // which happens in-between a chunk unload and the corresponding network element revalidation.
+                // In that case, we can not resolve our variable yet,
+                // so we schedule another aspect update, which retries this once the networks are set again.
+                this.requireAspectUpdate();
             } else {
-                getVariable(network, partNetwork, valueDeseralizationContext).addInvalidationListener(this::requireAspectUpdate);
+                IVariable<?> variable = getVariable(this.network, this.partNetwork, this.valueDeseralizationContext);
+                if (variable != null) {
+                    variable.addInvalidationListener(this::requireAspectUpdate);
+                }
             }
         }
 


### PR DESCRIPTION
Closes CyclopsMC/IntegratedDynamics#1711

## Problem

The crash reported in CyclopsMC/IntegratedDynamics#1711 happens on the server thread, during the Integrated Dynamics network tick:

```
java.lang.NullPointerException: Cannot invoke "org.cyclops.integrateddynamics.api.network.IPartNetwork.hasPartVariable(int, org.cyclops.integrateddynamics.api.part.aspect.IAspectRead)" because "partNetwork" is null
    at integrateddynamics/…AspectVariableFacade.getVariable(AspectVariableFacade.java:52)
    at integrateddynamics/…PartStateActiveVariableBase.getVariable(PartStateActiveVariableBase.java:109)
    at integratedtunnels/…PartTypeInterfacePositionedAddonFiltering$State.setTargetFilter(PartTypeInterfacePositionedAddonFiltering.java:235)
    at integratedtunnels/…TunnelAspectWriteBuilders.lambda$propSetFilter$0(TunnelAspectWriteBuilders.java:127)
    at integrateddynamics/…AspectWriteBase.update(AspectWriteBase.java:58)
    at integrateddynamics/…PartTypeWriteBase.update(PartTypeWriteBase.java:88)
    at integratedtunnels/…PartTypeInterfacePositionedAddonFiltering.update(PartTypeInterfacePositionedAddonFiltering.java:48)
    at integrateddynamics/…PartNetworkElement.update(PartNetworkElement.java:176)
    at integrateddynamics/…Network.update(Network.java:404)
    at integrateddynamics/…TickHandler.onTick(TickHandler.java:77)
```

`PartTypeInterfacePositionedAddonFiltering.State#setTargetFilter` resolved its variable through `getVariable(network, partNetwork, valueDeseralizationContext)`. Those three fields are only set by `setNetworks(…)` from `IPartTypeInterfacePositionedAddon#addTargetToNetwork`, and are explicitly reset to `null` by `removeTargetFromNetwork` — so they are `null` whenever the part is detached from its network.

That is exactly what happens in-between a chunk unload (`onNetworkRemoval` → `removeTargetFromNetwork`) and the corresponding network element revalidation: `Network#isValid` can let the element tick again before `afterNetworkReAlive` had a chance to re-attach the target, and `requireAspectUpdate` is still set, so the filter aspect re-executes and calls `setTargetFilter` with unset networks. Passing `null` as part network into `IVariableFacade#getVariable` then NPEs.

Note that the element's *own* network (the `network`/`partNetwork` arguments of `update`) is perfectly valid here — it is only the state's cached fields that are unset. That is why `AspectWriteBase#update` can resolve the active variable successfully first (which sets `checkedForWriteVariable`/`currentVariableFacade`), and the NPE then lands inside `AspectVariableFacade#getVariable` rather than during validation.

This also explains the second half of the report — the network staying broken afterwards. `Network#update` marks the network as crashed before rethrowing, that flag is persisted to NBT, and a crashed network is skipped in `TickHandler`, so the network stayed dead across the automatic server restart until one of its cables was broken and replaced.

## When was this introduced?

The unguarded dereference dates back to the introduction of filtering interfaces themselves, in 743b68f6 ("Add filtering ingredient interfaces, Closes #98", 2021-04-21), first released as **1.16.5-1.8.0**. That line has never checked whether the state's networks were set:

```java
getVariable(network, partNetwork).addInvalidationListener(this::requireAspectUpdate);
```

The very same chunk-unload/reload window was already reported once before, as #287 ("crash when loading back chunks with item interface"), and fixed in cf712218 (2024-04-08, released as **1.20.1-1.8.26**). That fix added the "Network may be null during chunk loading" guard around the `addTargetToNetwork` call in `TunnelAspectWriteBuilders#propSetFilter` — but the `setTargetFilter` call directly above it was left dereferencing the same unset fields, so the crash window was only half closed.

## Fix

When the networks are not set (yet), schedule another aspect update instead of resolving the variable. The filter and its invalidation listener are then applied on a later tick, once `addTargetToNetwork` has set the networks again — which is the same self-healing path already used for the `targetFilter == null` case.

## Testing

`master-1.20-lts` has no game test infrastructure (it was introduced on `master-1.21-lts`), so no automated test is included here.

A regression game test for `master-1.21-lts` is available separately, to be applied on top of the upmerge: it sets up an importer plus a filtering item interface, detaches the interface from its network the way `onNetworkRemoval` does on chunk unload, updates the part in that window, and then re-attaches it the way `afterNetworkReAlive` does on revalidation. Its filter variable is deliberately an *aspect* variable, since only `AspectVariableFacade` (and the operator/proxy facades) resolve themselves through the part network — an empty or value-based variable resolves to `DummyVariableFacade`, which ignores the part network and does not reproduce the crash.

That game test has been confirmed to reproduce the crash on `master-1.21-lts` without this fix.