### PR TITLE
Fix flaky testItemsInterfaceTargetPlacedLater game test

### DIFF
--- a/src/main/java/org/cyclops/integratedtunnels/gametest/GameTestsItems.java
+++ b/src/main/java/org/cyclops/integratedtunnels/gametest/GameTestsItems.java
@@ -1133,13 +1133,13 @@ public class GameTestsItems {
                 })
                 .thenIdle(TICKS_NETWORK_INIT)
                 .thenExecute(() -> helper.assertTrue(isInterfaceTargetValid(posInterface), "Interface did not expose the container that was placed later"))
-                // Only start exporting once the container is part of the network.
-                // An exporter that runs on an empty network first would fall asleep,
-                // and that sleep expires on wall-clock time rather than on ticks.
+                // Only start exporting once the container is part of the network
                 .thenExecute(() -> placeVariableInWriter(helper.getLevel(), PartPos.of(helper.getLevel(), helper.absolutePos(POS.east()), Direction.EAST),
                         TunnelAspects.Write.Item.BOOLEAN_EXPORT, new ItemStack(RegistryEntries.ITEM_VARIABLE)))
-                .thenIdle(TICKS_TRANSFER)
-                .thenExecute(() -> {
+                // The exporter can still run before the network observed the container that just
+                // joined it, after which it sleeps. That sleep expires on wall-clock time rather
+                // than on ticks, so wait for the transfer instead of asserting after fixed ticks.
+                .thenWaitUntil(() -> {
                     helper.assertContainerContains(POS.east().east(), Items.WHITE_WOOL);
                     helper.assertContainerEmpty(POS.west());
                 })


### PR DESCRIPTION
## Reproduction

The test fails as `Container should contain: minecraft:white_wool`, so the interface assertions pass and only the export is missing. It reproduced in CI before, in [run 33325803683 attempt 1](https://github.com/CyclopsMC/IntegratedTunnels/actions/runs/33325803683).

Running the test in its own game test batch makes it the only test on the server, which is its worst case: the game test server overrides `waitUntilNextTick` to not wait at all, so with nothing else to tick it runs far above 20 TPS. In that configuration the current test failed in 5 out of 5 runs.

## Cause

The exporter's first attempts run before the network has observed the container that just joined it, so nothing is moved and `TunnelHelpers#moveSingleStateOptimized` puts the connection to sleep after `GeneralConfig.inventoryUnchangedTickCount` (3) failed attempts.

That sleep lives in a Guava cache with `expireAfterWrite`, so it expires on wall-clock time (~650ms with the default config) and not on ticks. At 20 TPS that is the intended ~13 ticks, but at game test server speeds those same 650ms span several hundred ticks, well past the 100-tick (`TICKS_TRANSFER`) window the test asserted in.

Two experiments confirm this:
- With `GeneralConfig.inventoryUnchangedTickCount` temporarily raised so the exporter never sleeps, the 100-tick window passes every time.
- Widening the window instead of removing the sleep only shifts the odds: at 200 and 400 ticks the test still failed, at 800 it passed.

## Fix

Wait for the transfer rather than asserting it after a fixed number of ticks, like the other transfer assertions in this class already do.

Instrumenting the wait shows the transfer completing at test tick 43 when no sleep kicks in, and at 185-369 when it does, against the test's 2000-tick timeout.

## Validation

- 20 isolated runs of the fixed test (the configuration where the old test failed 5/5) all passed.
- `./gradlew build` passes.
- `./gradlew runGameTestServer` passes, 7 consecutive full runs, 150/150 tests each.

## Note

The three other tests in `GameTestsItems` that assert a transfer after `thenIdle(TICKS_TRANSFER)` are left untouched: their sources are already part of the network when the transfer starts, so no sleep kicks in, and they passed in the same isolated worst-case configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fmCwEgvp2MgAx5ZoFZrFu

---
_Generated by [Claude Code](https://claude.ai/code/session_013fmCwEgvp2MgAx5ZoFZrFu)_