### PR TITLE
Fix interfaces without filter not being closable with escape

### DIFF
--- a/src/main/java/org/cyclops/integratedtunnels/core/part/ContainerInterfaceSettings.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/part/ContainerInterfaceSettings.java
@@ -50,6 +50,14 @@ public class ContainerInterfaceSettings extends ContainerPartSettings {
         ValueNotifierHelpers.setValue(this, lastChannelInterfaceValueId, ((IPartTypeInterfacePositionedAddon.IState) getPartState()).getChannelInterface());
     }
 
+    /**
+     * @return If this container is the part's main gui,
+     *         as opposed to a settings sub-gui that was opened from within another part gui.
+     */
+    public boolean isPartGui() {
+        return getPartType() instanceof PartTypeInterfacePositionedAddon;
+    }
+
     public int getLastChannelInterfaceValueId() {
         return lastChannelInterfaceValueId;
     }

--- a/src/main/java/org/cyclops/integratedtunnels/core/part/ContainerScreenInterfaceSettings.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/part/ContainerScreenInterfaceSettings.java
@@ -86,10 +86,15 @@ public class ContainerScreenInterfaceSettings extends ContainerScreenPartSetting
 
     @Override
     public boolean keyPressed(int typedChar, int keyCode, int modifiers) {
-        if (typedChar != GLFW.GLFW_KEY_ESCAPE) {
-            if (this.numberFieldChannelInterface.keyPressed(typedChar, keyCode, modifiers)) {
+        if (typedChar == GLFW.GLFW_KEY_ESCAPE) {
+            if (getMenu().isPartGui()) {
+                // Interfaces without filter show these settings as their part gui,
+                // so escaping to the part gui would just re-open this gui.
+                onClose();
                 return true;
             }
+        } else if (this.numberFieldChannelInterface.keyPressed(typedChar, keyCode, modifiers)) {
+            return true;
         }
         return super.keyPressed(typedChar, keyCode, modifiers);
     }

--- a/src/main/java/org/cyclops/integratedtunnels/gametest/GameTestsGuis.java
+++ b/src/main/java/org/cyclops/integratedtunnels/gametest/GameTestsGuis.java
@@ -1,0 +1,76 @@
+package org.cyclops.integratedtunnels.gametest;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.gametest.framework.GameTest;
+import net.minecraft.gametest.framework.GameTestAssertException;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.MenuProvider;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.neoforge.gametest.GameTestHolder;
+import net.neoforged.neoforge.gametest.PrefixGameTestTemplate;
+import org.cyclops.integrateddynamics.RegistryEntries;
+import org.cyclops.integrateddynamics.api.part.IPartType;
+import org.cyclops.integrateddynamics.api.part.PartPos;
+import org.cyclops.integrateddynamics.core.helper.PartHelpers;
+import org.cyclops.integratedtunnels.Reference;
+import org.cyclops.integratedtunnels.core.part.ContainerInterfaceSettings;
+import org.cyclops.integratedtunnels.part.PartTypes;
+
+import java.util.Optional;
+
+/**
+ * Game tests for the gui containers of tunnel parts.
+ */
+@GameTestHolder(Reference.MOD_ID)
+@PrefixGameTestTemplate(false)
+public class GameTestsGuis {
+
+    public static final String TEMPLATE_EMPTY = "empty10";
+    public static final int TIMEOUT = 200;
+    public static final BlockPos POS = BlockPos.ZERO.offset(2, 0, 2);
+
+    /**
+     * Places the given part, and creates its interface settings container.
+     * @param settingsGui If the settings sub-gui must be created instead of the part's own gui.
+     */
+    private static ContainerInterfaceSettings createInterfaceSettingsMenu(GameTestHelper helper, IPartType<?, ?> partType,
+                                                                         boolean settingsGui) {
+        helper.setBlock(POS, RegistryEntries.BLOCK_CABLE.value());
+        PartHelpers.addPart(helper.getLevel(), helper.absolutePos(POS), Direction.WEST, partType, new ItemStack(partType.getItem()));
+        PartPos partPos = PartPos.of(helper.getLevel(), helper.absolutePos(POS), Direction.WEST);
+
+        //noinspection removal
+        ServerPlayer player = helper.makeMockServerPlayerInLevel();
+        Optional<MenuProvider> containerProvider = settingsGui
+                ? partType.getContainerProviderSettings(partPos)
+                : partType.getContainerProvider(partPos);
+        AbstractContainerMenu menu = containerProvider
+                .orElseThrow(() -> new GameTestAssertException("No container provider for " + partType))
+                .createMenu(0, player.getInventory(), player);
+
+        helper.assertTrue(menu instanceof ContainerInterfaceSettings,
+                "Expected an interface settings container, but got " + menu);
+        return (ContainerInterfaceSettings) menu;
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = TIMEOUT)
+    public void testInterfaceSettingsAreShownAsPartGui(GameTestHelper helper) {
+        // Interfaces without filter have no separate part gui,
+        // as their settings gui is opened directly when right-clicking them.
+        ContainerInterfaceSettings menu = createInterfaceSettingsMenu(helper, PartTypes.INTERFACE_ITEM, false);
+        helper.assertTrue(menu.isPartGui(), "Interface settings gui is not marked as part gui");
+        helper.succeed();
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY, timeoutTicks = TIMEOUT)
+    public void testFilteringInterfaceSettingsAreShownAsSubGui(GameTestHelper helper) {
+        // Filtering interfaces do have a separate part gui, from which the settings gui can be opened.
+        ContainerInterfaceSettings menu = createInterfaceSettingsMenu(helper, PartTypes.INTERFACE_FILTERING_ITEM, true);
+        helper.assertFalse(menu.isPartGui(), "Filtering interface settings gui is marked as part gui");
+        helper.succeed();
+    }
+
+}


### PR DESCRIPTION
Closes CyclopsMC/IntegratedDynamics#1726

## Problem

Right-clicking an item/fluid/energy interface opens a gui that can no longer be left.

`PartTypeInterfacePositionedAddon#getContainerProvider` uses `ContainerInterfaceSettings` as the part's *own* gui, so for these interfaces the part settings gui and the part gui are one and the same.

Since IntegratedDynamics `0c4c502` (CyclopsMC/IntegratedDynamics#1713), `ContainerScreenPartSettings#keyPressed` no longer closes on escape, but calls `exitToPartGui()`, which presses the save button, which makes the server call `PartHelpers.openContainerPart(...)`. For these interfaces that re-opens the exact same gui, so nothing appears to happen. Escape is the only key that gets that far, since that same `keyPressed` returns `true` for every other key so that typing in the settings fields works, which is why the inventory key does nothing either.

Filtering interfaces are unaffected: their part gui is the aspects gui, from which the settings gui is opened as a sub-gui.

## Solution

`ContainerInterfaceSettings#isPartGui` reports whether these settings are shown as the part's own gui. If so, `ContainerScreenInterfaceSettings` closes on escape instead of delegating to the part gui logic. Settings are still saved on close, by the existing `onClose` auto-save.

Escape is handled before the super call, so this also works on IntegratedDynamics versions from before CyclopsMC/IntegratedDynamics#1713.

## Testing

* Added `GameTestsGuis` asserting that the item interface's part gui is marked as part gui, and that the filtering item interface's settings sub-gui is not.
* `./gradlew build` and `./gradlew runGameTestServer` pass (152 game tests).

Note that the fix itself is client-side gui code, which game tests cannot cover; only the condition it keys off is tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RfuroLcUqKfUq8yaEeBrRm

---
_Generated by [Claude Code](https://claude.ai/code/session_01RfuroLcUqKfUq8yaEeBrRm)_