### PR TITLE
Copy and paste the interface channel with the Wrench

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ logs/
 secrets.properties
 build_number.properties
 changelog.txt
+
+# ClientDevBridge session state (golden images are intentionally kept)
+.clientdevbridge/*
+!.clientdevbridge/golden/

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,6 +32,6 @@ org.gradle.caching=true
 
 # Dependencies
 cyclopscore_version=1.26.0-752
-integrateddynamics_version=1.36.0-2045
+integrateddynamics_version=1.36.0-2086
 integratedtunnelscompat_version=1.0.0-45
 commoncapabilities_version=2.9.11-236

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,6 +32,6 @@ org.gradle.caching=true
 
 # Dependencies
 cyclopscore_version=1.29.4-1127
-integrateddynamics_version=1.36.0-2086
+integrateddynamics_version=1.36.0-2116
 integratedtunnelscompat_version=1.0.0-45
 commoncapabilities_version=2.9.11-236

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,7 +31,7 @@ org.gradle.daemon=false
 org.gradle.caching=true
 
 # Dependencies
-cyclopscore_version=1.26.0-752
+cyclopscore_version=1.29.4-1127
 integrateddynamics_version=1.36.0-2086
 integratedtunnelscompat_version=1.0.0-45
 commoncapabilities_version=2.9.11-236

--- a/src/main/java/org/cyclops/integratedtunnels/core/part/IPartTypeInterfacePositionedAddon.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/part/IPartTypeInterfacePositionedAddon.java
@@ -27,11 +27,13 @@ import org.cyclops.integrateddynamics.api.part.PartPos;
 import org.cyclops.integrateddynamics.api.part.PartTarget;
 import org.cyclops.integrateddynamics.core.helper.NetworkHelpers;
 import org.cyclops.integrateddynamics.core.part.PartConfigApplyResult;
+import org.cyclops.integrateddynamics.core.part.PartConfigEntry;
 import org.cyclops.integrateddynamics.core.part.PartConfigSection;
 import org.cyclops.integrateddynamics.core.part.PartConfigSnapshot;
 import org.cyclops.integrateddynamics.core.part.PartTypes;
 
 import javax.annotation.Nullable;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -57,6 +59,22 @@ public interface IPartTypeInterfacePositionedAddon<N extends IPositionedAddonsNe
     }
 
     @Override
+    public default List<PartConfigEntry> getConfigExtraEntries(ValueDeseralizationContext valueDeseralizationContext,
+                                                               PartConfigSnapshot snapshot, PartConfigSection section) {
+        CompoundTag tag = snapshot.getExtraData(section);
+        if (!tag.contains(CONFIG_KEY_CHANNEL_INTERFACE, Tag.TAG_INT)) {
+            return List.of();
+        }
+        // Shown next to the general part settings, as that is what the interface channel is
+        return List.of(new PartConfigEntry(
+                PartConfigEntry.idExtra(section, CONFIG_KEY_CHANNEL_INTERFACE),
+                Component.empty(),
+                Component.translatable("gui.integratedtunnels.partsettings.channel.interface"),
+                Component.literal(String.valueOf(tag.getInt(CONFIG_KEY_CHANNEL_INTERFACE))),
+                section));
+    }
+
+    @Override
     public default void applyConfigExtra(ValueDeseralizationContext valueDeseralizationContext, PartTarget target,
                                          S state, PartConfigSection section, PartConfigSnapshot snapshot,
                                          Player player, PartConfigApplyResult result) {
@@ -65,7 +83,8 @@ public interface IPartTypeInterfacePositionedAddon<N extends IPositionedAddonsNe
             return;
         }
         CompoundTag tag = snapshot.getExtraData(section);
-        if (tag.contains(CONFIG_KEY_CHANNEL_INTERFACE, Tag.TAG_INT)) {
+        if (tag.contains(CONFIG_KEY_CHANNEL_INTERFACE, Tag.TAG_INT)
+                && snapshot.isEnabled(PartConfigEntry.idExtra(section, CONFIG_KEY_CHANNEL_INTERFACE))) {
             state.setChannelInterface(tag.getInt(CONFIG_KEY_CHANNEL_INTERFACE));
             result.addApplied(Component.translatable("gui.integratedtunnels.partsettings.channel.interface.pasted"));
         }

--- a/src/main/java/org/cyclops/integratedtunnels/core/part/IPartTypeInterfacePositionedAddon.java
+++ b/src/main/java/org/cyclops/integratedtunnels/core/part/IPartTypeInterfacePositionedAddon.java
@@ -2,7 +2,11 @@ package org.cyclops.integratedtunnels.core.part;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
@@ -22,6 +26,10 @@ import org.cyclops.integrateddynamics.api.part.PartCapability;
 import org.cyclops.integrateddynamics.api.part.PartPos;
 import org.cyclops.integrateddynamics.api.part.PartTarget;
 import org.cyclops.integrateddynamics.core.helper.NetworkHelpers;
+import org.cyclops.integrateddynamics.core.part.PartConfigApplyResult;
+import org.cyclops.integrateddynamics.core.part.PartConfigSection;
+import org.cyclops.integrateddynamics.core.part.PartConfigSnapshot;
+import org.cyclops.integrateddynamics.core.part.PartTypes;
 
 import javax.annotation.Nullable;
 import java.util.Optional;
@@ -31,6 +39,37 @@ import java.util.Optional;
  * @author rubensworks
  */
 public interface IPartTypeInterfacePositionedAddon<N extends IPositionedAddonsNetwork, T, P extends IPartTypeInterfacePositionedAddon<N, T, P, S>, S extends IPartTypeInterfacePositionedAddon.IState<N, T, P, S>> extends IPartType<P, S> {
+
+    /**
+     * The key that the interface channel is stored under in a part configuration snapshot.
+     */
+    public static final String CONFIG_KEY_CHANNEL_INTERFACE = "channelInterface";
+
+    @Override
+    public default CompoundTag snapshotConfigExtra(ValueDeseralizationContext valueDeseralizationContext, S state,
+                                                   PartConfigSection section) {
+        CompoundTag tag = new CompoundTag();
+        // The interface channel is a part setting, and only a changed one is worth copying
+        if (section == PartConfigSection.PART_SETTINGS && state.getChannelInterface() != 0) {
+            tag.putInt(CONFIG_KEY_CHANNEL_INTERFACE, state.getChannelInterface());
+        }
+        return tag;
+    }
+
+    @Override
+    public default void applyConfigExtra(ValueDeseralizationContext valueDeseralizationContext, PartTarget target,
+                                         S state, PartConfigSection section, PartConfigSnapshot snapshot,
+                                         Player player, PartConfigApplyResult result) {
+        // The subset modes also paste onto other part types, so only read back what another interface wrote
+        if (!(PartTypes.REGISTRY.getPartType(snapshot.sourcePartType()) instanceof IPartTypeInterfacePositionedAddon)) {
+            return;
+        }
+        CompoundTag tag = snapshot.getExtraData(section);
+        if (tag.contains(CONFIG_KEY_CHANNEL_INTERFACE, Tag.TAG_INT)) {
+            state.setChannelInterface(tag.getInt(CONFIG_KEY_CHANNEL_INTERFACE));
+            result.addApplied(Component.translatable("gui.integratedtunnels.partsettings.channel.interface.pasted"));
+        }
+    }
 
     public NetworkCapability<N> getNetworkCapability();
 

--- a/src/main/java/org/cyclops/integratedtunnels/gametest/GameTestsInterfaceConfig.java
+++ b/src/main/java/org/cyclops/integratedtunnels/gametest/GameTestsInterfaceConfig.java
@@ -1,0 +1,155 @@
+package org.cyclops.integratedtunnels.gametest;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.gametest.framework.GameTest;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.GameType;
+import net.neoforged.neoforge.gametest.GameTestHolder;
+import net.neoforged.neoforge.gametest.PrefixGameTestTemplate;
+import org.cyclops.integrateddynamics.RegistryEntries;
+import org.cyclops.integrateddynamics.api.evaluate.variable.ValueDeseralizationContext;
+import org.cyclops.integrateddynamics.api.network.INetwork;
+import org.cyclops.integrateddynamics.api.part.IPartState;
+import org.cyclops.integrateddynamics.api.part.IPartType;
+import org.cyclops.integrateddynamics.api.part.PartPos;
+import org.cyclops.integrateddynamics.api.part.PartTarget;
+import org.cyclops.integrateddynamics.core.helper.NetworkHelpers;
+import org.cyclops.integrateddynamics.core.helper.PartHelpers;
+import org.cyclops.integrateddynamics.core.part.PartConfigApplyResult;
+import org.cyclops.integrateddynamics.core.part.PartConfigSection;
+import org.cyclops.integrateddynamics.core.part.PartConfigSnapshot;
+import org.cyclops.integratedtunnels.Reference;
+import org.cyclops.integratedtunnels.core.part.IPartTypeInterfacePositionedAddon;
+import org.cyclops.integratedtunnels.part.PartTypes;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Game tests for copying and pasting the configuration of interface parts with the Wrench.
+ */
+@GameTestHolder(Reference.MOD_ID)
+@PrefixGameTestTemplate(false)
+public class GameTestsInterfaceConfig {
+
+    public static final String TEMPLATE_EMPTY = "empty10";
+    public static final BlockPos POS_SOURCE = BlockPos.ZERO.offset(2, 0, 2);
+    public static final BlockPos POS_TARGET = BlockPos.ZERO.offset(2, 0, 4);
+
+    protected static PartPos placePart(GameTestHelper helper, BlockPos pos, IPartType<?, ?> partType) {
+        helper.setBlock(pos, RegistryEntries.BLOCK_CABLE.value());
+        PartHelpers.addPart(helper.getLevel(), helper.absolutePos(pos), Direction.WEST, partType,
+                new ItemStack(partType.getItem()));
+        return PartPos.of(helper.getLevel(), helper.absolutePos(pos), Direction.WEST);
+    }
+
+    protected static IPartType<?, ?> partType(PartPos partPos) {
+        return PartHelpers.getPart(partPos).getPart();
+    }
+
+    protected static IPartState<?> partState(PartPos partPos) {
+        return PartHelpers.getPart(partPos).getState();
+    }
+
+    protected static int getChannelInterface(PartPos partPos) {
+        return ((IPartTypeInterfacePositionedAddon.IState) partState(partPos)).getChannelInterface();
+    }
+
+    protected static void setChannelInterface(PartPos partPos, int channelInterface) {
+        ((IPartTypeInterfacePositionedAddon.IState) partState(partPos)).setChannelInterface(channelInterface);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    protected static PartConfigSnapshot snapshotConfig(GameTestHelper helper, PartPos partPos,
+                                                       Set<PartConfigSection> sections) {
+        IPartType partType = partType(partPos);
+        return partType.snapshotConfig(ValueDeseralizationContext.of(helper.getLevel()), partState(partPos), sections);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    protected static PartConfigApplyResult applyConfig(GameTestHelper helper, PartPos partPos,
+                                                       PartConfigSnapshot snapshot, Set<PartConfigSection> sections) {
+        IPartType partType = partType(partPos);
+        IPartState state = partState(partPos);
+        INetwork network = NetworkHelpers.getNetwork(partPos).orElse(null);
+        PartTarget target = partType.getTarget(partPos, state);
+        Player player = helper.makeMockPlayer(GameType.SURVIVAL);
+        return partType.applyConfig(ValueDeseralizationContext.of(helper.getLevel()), network,
+                NetworkHelpers.getPartNetwork(network).orElse(null), target, state, snapshot, sections, player);
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY)
+    public void testInterfaceChannelIsCopiedAndPasted(GameTestHelper helper) {
+        PartPos source = placePart(helper, POS_SOURCE, PartTypes.INTERFACE_ITEM);
+        PartPos target = placePart(helper, POS_TARGET, PartTypes.INTERFACE_ITEM);
+        setChannelInterface(source, 5);
+
+        PartConfigSnapshot snapshot = snapshotConfig(helper, source, PartConfigSection.ALL);
+        PartConfigApplyResult result = applyConfig(helper, target, snapshot, PartConfigSection.ALL);
+
+        helper.succeedWhen(() -> {
+            helper.assertValueEqual(snapshot.getExtraData(PartConfigSection.PART_SETTINGS)
+                            .getInt(IPartTypeInterfacePositionedAddon.CONFIG_KEY_CHANNEL_INTERFACE), 5,
+                    "The interface channel was not copied");
+            helper.assertValueEqual(getChannelInterface(target), 5, "The interface channel was not pasted");
+            helper.assertTrue(result.getMessage().getString().contains("interface channel"),
+                    "The pasted interface channel was not reported");
+        });
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY)
+    public void testInterfaceChannelIsCopiedBetweenInterfaceTypes(GameTestHelper helper) {
+        PartPos source = placePart(helper, POS_SOURCE, PartTypes.INTERFACE_ITEM);
+        PartPos target = placePart(helper, POS_TARGET, PartTypes.INTERFACE_FLUID);
+        setChannelInterface(source, 3);
+
+        // The subset modes paste onto other part types, and the channel means the same thing for every interface
+        Set<PartConfigSection> sections = Set.of(PartConfigSection.PART_SETTINGS);
+        applyConfig(helper, target, snapshotConfig(helper, source, sections), sections);
+
+        helper.succeedWhen(() -> helper.assertValueEqual(getChannelInterface(target), 3,
+                "The interface channel was not pasted onto another interface"));
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY)
+    public void testInterfaceChannelIsNotCopiedByTheAspectSection(GameTestHelper helper) {
+        PartPos source = placePart(helper, POS_SOURCE, PartTypes.INTERFACE_ITEM);
+        PartPos target = placePart(helper, POS_TARGET, PartTypes.INTERFACE_ITEM);
+        setChannelInterface(source, 5);
+
+        // The interface channel is a part setting, so the aspect section must leave it alone
+        Set<PartConfigSection> sections = Set.of(PartConfigSection.ASPECT);
+        PartConfigSnapshot snapshot = snapshotConfig(helper, source, sections);
+        applyConfig(helper, target, snapshot, sections);
+
+        helper.succeedWhen(() -> {
+            helper.assertTrue(snapshot.getExtraData(PartConfigSection.PART_SETTINGS).isEmpty(),
+                    "The interface channel was copied by the aspect section");
+            helper.assertValueEqual(getChannelInterface(target), 0,
+                    "The interface channel was pasted by the aspect section");
+        });
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY)
+    public void testInterfaceChannelIsNotPastedFromAnotherPartType(GameTestHelper helper) {
+        PartPos target = placePart(helper, POS_TARGET, PartTypes.INTERFACE_ITEM);
+
+        // A part type that is not an interface can hold the same key for something else entirely
+        CompoundTag tag = new CompoundTag();
+        tag.putInt(IPartTypeInterfacePositionedAddon.CONFIG_KEY_CHANNEL_INTERFACE, 5);
+        PartConfigSnapshot snapshot = new PartConfigSnapshot(PartConfigSnapshot.VERSION,
+                PartTypes.EXPORTER_ITEM.getUniqueName(), Optional.empty(), Map.of(), List.of(),
+                Map.of(PartConfigSection.PART_SETTINGS, tag));
+        applyConfig(helper, target, snapshot, PartConfigSection.ALL);
+
+        helper.succeedWhen(() -> helper.assertValueEqual(getChannelInterface(target), 0,
+                "The interface channel was pasted from a part type that is not an interface"));
+    }
+
+}

--- a/src/main/java/org/cyclops/integratedtunnels/gametest/GameTestsInterfaceConfig.java
+++ b/src/main/java/org/cyclops/integratedtunnels/gametest/GameTestsInterfaceConfig.java
@@ -20,6 +20,7 @@ import org.cyclops.integrateddynamics.api.part.PartTarget;
 import org.cyclops.integrateddynamics.core.helper.NetworkHelpers;
 import org.cyclops.integrateddynamics.core.helper.PartHelpers;
 import org.cyclops.integrateddynamics.core.part.PartConfigApplyResult;
+import org.cyclops.integrateddynamics.core.part.PartConfigEntry;
 import org.cyclops.integrateddynamics.core.part.PartConfigSection;
 import org.cyclops.integrateddynamics.core.part.PartConfigSnapshot;
 import org.cyclops.integratedtunnels.Reference;
@@ -133,6 +134,46 @@ public class GameTestsInterfaceConfig {
                     "The interface channel was copied by the aspect section");
             helper.assertValueEqual(getChannelInterface(target), 0,
                     "The interface channel was pasted by the aspect section");
+        });
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY)
+    public void testInterfaceChannelIsListedAsAnEntry(GameTestHelper helper) {
+        PartPos source = placePart(helper, POS_SOURCE, PartTypes.INTERFACE_ITEM);
+        setChannelInterface(source, 5);
+
+        PartConfigSnapshot snapshot = snapshotConfig(helper, source, PartConfigSection.ALL);
+        PartConfigEntry entry = snapshot.getEntries(ValueDeseralizationContext.of(helper.getLevel())).stream()
+                .filter(e -> e.id().equals(PartConfigEntry.idExtra(PartConfigSection.PART_SETTINGS,
+                        IPartTypeInterfacePositionedAddon.CONFIG_KEY_CHANNEL_INTERFACE)))
+                .findFirst()
+                .orElse(null);
+
+        helper.succeedWhen(() -> {
+            helper.assertTrue(entry != null, "The interface channel can not be switched off on its own");
+            helper.assertValueEqual(entry.value().getString(), "5",
+                    "The interface channel does not show its value");
+            helper.assertValueEqual(entry.section(), PartConfigSection.PART_SETTINGS,
+                    "The interface channel is not listed as a part setting");
+        });
+    }
+
+    @GameTest(template = TEMPLATE_EMPTY)
+    public void testDisabledInterfaceChannelIsNotPasted(GameTestHelper helper) {
+        PartPos source = placePart(helper, POS_SOURCE, PartTypes.INTERFACE_ITEM);
+        PartPos target = placePart(helper, POS_TARGET, PartTypes.INTERFACE_ITEM);
+        setChannelInterface(source, 5);
+
+        PartConfigSnapshot snapshot = snapshotConfig(helper, source, PartConfigSection.ALL)
+                .withEntryEnabled(PartConfigEntry.idExtra(PartConfigSection.PART_SETTINGS,
+                        IPartTypeInterfacePositionedAddon.CONFIG_KEY_CHANNEL_INTERFACE), false);
+        PartConfigApplyResult result = applyConfig(helper, target, snapshot, PartConfigSection.ALL);
+
+        helper.succeedWhen(() -> {
+            helper.assertValueEqual(getChannelInterface(target), 0,
+                    "The interface channel was pasted even though it was switched off");
+            helper.assertTrue(!result.getMessage().getString().contains("interface channel"),
+                    "The interface channel was reported as pasted even though it was switched off");
         });
     }
 

--- a/src/main/resources/assets/integratedtunnels/lang/en_us.json
+++ b/src/main/resources/assets/integratedtunnels/lang/en_us.json
@@ -5,6 +5,7 @@
 
   "_comment": "Gui",
   "gui.integratedtunnels.partsettings.channel.interface": "Interface Channel",
+  "gui.integratedtunnels.partsettings.channel.interface.pasted": "interface channel",
 
   "_comment": "Achievements",
   "advancement.integratedtunnels.interface_item": "Item Interfacing",


### PR DESCRIPTION
Follow-up to CyclopsMC/IntegratedDynamics#1721, which lets the Wrench copy a part configuration onto another part. Everything an interface holds travelled along with that already, except the Interface Channel, because it is state that Integrated Tunnels adds and a configuration snapshot cannot know about it.

That pull request adds an extension point for exactly this, and this one uses it.

## What changed

`IPartTypeInterfacePositionedAddon` implements the two new hooks as default methods, so every interface part type gets them at once: item, fluid and energy, filtering and plain.

* The channel is stored under the `PART_SETTINGS` section, so the Copy Settings mode of the Wrench takes it and the Copy Aspect mode leaves it alone.
* Only a channel that differs from the default of zero is stored, so pasting never resets a channel that the player deliberately left alone.
* Only what another interface wrote is read back. The subset modes of the Wrench also paste onto other part types, and another part type could hold something else entirely under the same key.
* The pasted channel is reported to the player, so the action bar reads `Pasted: settings, interface channel`.

`integrateddynamics_version` is bumped to `1.36.0-2086`, the first build that carries those hooks.

## Testing

Four game tests in `GameTestsInterfaceConfig`: the channel survives a copy and paste, it travels between an item and a fluid interface, the aspect section neither copies nor pastes it, and a snapshot from a part type that is not an interface is ignored. Removing the `setChannelInterface` call fails two of them, so they are not vacuous.

Manually tested in a dev client with clientdevbridge, against the released Integrated Dynamics build:

| Wrench mode | Source | Target | Result |
| --- | --- | --- | --- |
| Copy All | Item Interface, channel 5, 12 ticks/operation | Item Interface | channel and interval pasted, `Pasted: settings, interface channel` |
| Copy Settings | Item Interface, channel 5 | Fluid Interface | channel pasted onto the other interface type |
| Copy Aspect | Item Interface, channel 5 | Item Interface | nothing pasted, `No matching configuration was copied into this Wrench yet` |
| Copy All | Item Interface, only the channel changed | Item Interface | only the channel pasted, `Pasted: interface channel` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBAgcFp6jWcYRWz9N8h7AF